### PR TITLE
feat: Maxwell Q&A improvements, invite link UX, observation context

### DIFF
--- a/.kiro/specs/maxwell-know-your-rights/design.md
+++ b/.kiro/specs/maxwell-know-your-rights/design.md
@@ -1,0 +1,624 @@
+# Design: Maxwell "Know Your Rights" Skill
+
+## 1. Architecture Overview
+
+The Know Your Rights skill is a **prompt mode addition** to the existing Maxwell architecture. It follows the identical pattern used by storage and quantitative modes: keyword regex detection → prompt file loading → instruction block prepended to user message.
+
+```
+User Message
+    │
+    ▼
+detectPromptMode(message)        ← NEW: RIGHTS_KEYWORDS regex checked here
+    │
+    ├─ RIGHTS_KEYWORDS match  → RIGHTS_PROMPT (loaded from rights.txt)
+    ├─ STORAGE_KEYWORDS match → STORAGE_PROMPT
+    ├─ QUANTITATIVE_KEYWORDS  → QUANTITATIVE_PROMPT
+    └─ default                → GENERAL_PROMPT
+    │
+    ▼
+buildInstructionPrefix()
+    │
+    ▼
+"[Instructions: ${TONE_PROMPT}\n\n${RIGHTS_PROMPT}]\n\n" + context + message
+    │
+    ▼
+Bedrock Agent (CNV04Q1OAZ)
+    │
+    ├─ Uses GetEntityObservations (with dateFrom/dateTo) for evidence
+    ├─ Uses UnifiedSearch for cross-entity context
+    └─ Returns markdown with ![photo](url) for evidence images
+    │
+    ▼
+Response streamed to client → Rich copy via copyConversationRich()
+```
+
+**No new infrastructure required:**
+- No new Lambda functions
+- No new API endpoints
+- No new database tables
+- No new Bedrock Agent action groups
+- No new frontend components
+
+The three sub-modes (proactive, evaluative, report) are handled **within the prompt itself** — the LLM distinguishes intent from the user's message content. A single `rights.txt` prompt file covers all three modes with explicit instructions for each.
+
+## 2. Prompt Mode Detection
+
+### Priority Order
+
+Rights detection is inserted **before** storage and quantitative in the detection chain. This is because rights-related queries could incidentally contain quantitative words (e.g., "how much time did SSS make me wait") but should be routed to the rights mode.
+
+```javascript
+// New constant loaded at cold start
+const RIGHTS_PROMPT = loadPrompt('rights.txt');
+
+// New regex — checks BEFORE storage and quantitative
+const RIGHTS_KEYWORDS = /\b(rights?|file|report|complain(t|ts)?|violat(e|ed|ion|ions)|charter|consumer|accountability|escalat(e|ion)|who do i report|arta|dti|npc|dole|ntc|due process|red tape|anti.?red.?tape|citizen.?s?.?charter|refund|return policy|labor (code|law|rights)|tenant.?s?.?rights?|landlord)\b/i;
+```
+
+### Updated `detectPromptMode` Function
+
+```javascript
+function detectPromptMode(message) {
+  if (RIGHTS_PROMPT && RIGHTS_KEYWORDS.test(message)) return RIGHTS_PROMPT;
+  if (STORAGE_PROMPT && STORAGE_KEYWORDS.test(message)) return STORAGE_PROMPT;
+  if (QUANTITATIVE_PROMPT && QUANTITATIVE_KEYWORDS.test(message)) return QUANTITATIVE_PROMPT;
+  return GENERAL_PROMPT;
+}
+```
+
+### Sub-Mode Detection (Within the Prompt)
+
+The three sub-modes are **not** detected by separate regexes. Instead, the prompt instructs the LLM to determine the mode from context:
+
+| Sub-Mode | Detection Signal (by LLM) | Trigger Examples |
+|----------|--------------------------|------------------|
+| **Proactive** | User asks about rights in a hypothetical/upcoming situation, OR no entity context is available | "What are my rights at SSS?", "What should I expect from Lazada returns?" |
+| **Evaluative** | User asks for assessment of a past experience; entity observations exist | "Were my rights violated?", "Did they follow proper procedure?" |
+| **Report** | User explicitly requests a report or document for filing | "Generate a report", "Help me file against SSS", "I want to report this" |
+
+This keeps the implementation simple (one regex, one prompt file) while giving the LLM clear instructions to adapt its response format.
+
+## 3. Prompt File Content
+
+File: `lambda/ws-maxwell-worker/prompts/sonnet46/rights.txt`
+
+```
+The user is asking about their rights in relation to a counterparty (government agency, seller, employer, service provider, landlord, telco, platform, etc.).
+
+Determine which mode applies based on the user's message and available context:
+
+---
+
+MODE 1: PROACTIVE (Rights Awareness)
+Trigger: The user asks what their rights are in a situation, OR asks what to expect. No assessment of a past event is requested.
+
+Use this response format:
+
+**Your Rights: [Situation]**
+
+**Applicable Framework**
+- Name the specific law, regulation, charter, or policy that applies (e.g., "Anti-Red Tape Act (RA 11032)", "DTI Consumer Act (RA 7394)", "Lazada Return & Refund Policy")
+- Jurisdiction: Philippines unless user specifies otherwise
+
+**What You're Entitled To**
+- Each specific right or standard, with concrete details (processing times, fees, required documents)
+- Use bullet points, bold the key obligation
+
+**If They Don't Comply**
+- Escalation path: which oversight body, how to file, contact details if known
+- Timeline: how long they have to respond to a complaint
+
+**Practical Tips**
+- What to document (photos, names, timestamps) in case you need to escalate later
+
+---
+
+MODE 2: EVALUATIVE (Were My Rights Violated?)
+Trigger: The user asks Maxwell to assess whether their rights were violated based on their experience. Entity observations are typically available.
+
+First, call GetEntityObservations to retrieve the user's logged experience. If the user mentions a date range, use dateFrom/dateTo parameters.
+
+Use this response format:
+
+**Rights Assessment: [Entity/Counterparty]**
+
+**Applicable Standard**
+- The specific law/charter/policy and what it requires
+
+**What Happened (from your observations)**
+- Chronological summary drawn from observations, citing dates and details
+- Include photos inline: ![description](url)
+
+**Assessment**
+For each relevant standard:
+- ✅ **[Standard]**: Met — [brief explanation]
+- ❌ **[Standard]**: Violated — [what the standard requires vs. what happened]
+
+**Conclusion**
+- Clear factual statement: "Based on [N] documented interactions, [X] of [Y] applicable standards were not met."
+- If no violations found: "Your experience appears compliant with [framework]. Here's why: [explanation]"
+
+**If You Want to Escalate**
+- Which oversight body has jurisdiction
+- Whether the evidence is sufficient (photos, timestamps, documented interactions)
+- What additional documentation would strengthen a case
+
+---
+
+MODE 3: REPORT (Rights Violation Report Generation)
+Trigger: The user explicitly asks for a report, wants to file a complaint, or says "generate a report", "help me file", "I want to report this".
+
+First, call GetEntityObservations to retrieve ALL observations (with photos). Use dateFrom/dateTo if the user specifies a period. If no entity context exists, ask the user which entity contains their evidence.
+
+Use this response format:
+
+# Rights Violation Report
+
+**Filed Against:** [Counterparty name and branch/location if known]
+**Complainant:** [From organization context — do not ask unless unavailable]
+**Date of Report:** [Today's date]
+**Period Covered:** [Date range of observations]
+
+## Applicable Rights & Standards
+
+[List each applicable law, regulation, charter commitment, or policy with its specific relevant provisions. Cite section numbers where possible.]
+
+## Timeline of Events
+
+[Chronological account drawn from observations. Each entry:]
+
+**[Date] — [Summary]**
+[Details from observation text]
+
+![Photo description](photo_url)
+*[Caption explaining what the photo shows as evidence]*
+
+[Repeat for each relevant observation]
+
+## Violations Identified
+
+| # | Standard/Provision | Requirement | What Happened | Evidence |
+|---|---|---|---|---|
+| 1 | [e.g., RA 11032 §9] | [What it requires] | [What actually happened] | [Date, photo ref] |
+
+## Complainant's Statement
+
+[Include any additional context the user provided in their prompt that isn't in the observations. Label clearly: "Complainant states: ..."]
+
+## Supporting Evidence Summary
+
+- **Documented observations:** [count] entries with timestamps
+- **Photo evidence:** [count] photos
+- **Period documented:** [first date] to [last date]
+
+## Recommended Filing
+
+**Oversight Body:** [e.g., ARTA, DTI, NPC, DOLE, NTC, or relevant court]
+**How to File:**
+- Online: [portal URL if known]
+- Email: [address if known]
+- In person: [office location if known]
+**Expected Response Time:** [statutory timeframe if applicable]
+
+---
+
+IMPORTANT RULES FOR ALL MODES:
+- Default jurisdiction: Philippines. Adapt if the user mentions another country.
+- Use the LLM's training knowledge for laws, charters, and policies. Do NOT claim you need to look up a database — you know Philippine consumer protection law, ARTA, labor code, etc.
+- When referencing observations, always use data from GetEntityObservations. Never fabricate observation content.
+- Display ALL photos from observations inline as ![description](url) — these are critical evidence.
+- When no observations are available and the user is in evaluative/report mode, inform them: "I don't see any logged observations for this entity. Would you like me to explain your rights (proactive mode), or can you point me to the entity where you logged your experience?"
+- In report mode, distinguish between documented evidence (observations with timestamps/photos) and user-stated claims (verbal context provided in the prompt). Label user-stated claims as "Complainant states:" in the report.
+- Be factual and precise. State what the standard requires vs. what happened. Do NOT render legal judgments (e.g., don't say "they are liable"). State facts and let the oversight body adjudicate.
+- When the user provides supplemental context in their message (e.g., "I spent 4 hours", "they made me come back 3 times"), incorporate it in the report under "Complainant's Statement" — clearly marked as unverified user-reported context.
+```
+
+## 4. Data Flow
+
+### Proactive Mode (No Observations Needed)
+
+```
+User: "What are my rights at SSS?"
+    │
+    ▼
+RIGHTS_KEYWORDS matches "rights"
+    │
+    ▼
+buildInstructionPrefix → prepends rights.txt prompt
+    │
+    ▼
+Bedrock Agent receives:
+  "[Instructions: {tone}\n\n{rights prompt}]\n\n[Today's date: 2026-06-30] What are my rights at SSS?"
+    │
+    ▼
+Agent responds from LLM knowledge (Philippine SSS Citizens' Charter, RA 11032)
+  — NO tool calls needed
+    │
+    ▼
+Response streamed to client
+```
+
+### Evaluative Mode (Observations Retrieved)
+
+```
+User: "Were my rights violated at SSS today?"
+(with entity context: entityId="sss-sapian", entityType="action", entityName="SSS Visit")
+    │
+    ▼
+RIGHTS_KEYWORDS matches "rights" and "violated"
+    │
+    ▼
+buildInstructionPrefix → prepends rights.txt prompt
+    │
+    ▼
+Enhanced message includes [Context: You are discussing action "SSS Visit" (ID: sss-sapian)]
+    │
+    ▼
+Bedrock Agent:
+  1. Calls GetEntityObservations(entityId="sss-sapian", entityType="action")
+  2. Receives observations: [{text, photos: [{photo_url, photo_description, transcription}], metrics, created_at}]
+  3. LLM compares observations against SSS Citizens' Charter standards
+    │
+    ▼
+Response includes:
+  - Chronological summary citing observation dates
+  - Photos inline: ![Long queue at SSS window 3](https://cdn.../photo.jpg)
+  - ✅/❌ assessment per standard
+    │
+    ▼
+Response streamed to client
+```
+
+### Report Mode (Full Evidence Compilation)
+
+```
+User: "Generate a rights violation report against SSS. I spent 4 hours and they made me come back twice."
+(with entity context available)
+    │
+    ▼
+RIGHTS_KEYWORDS matches "report"
+    │
+    ▼
+buildInstructionPrefix → prepends rights.txt prompt
+    │
+    ▼
+Bedrock Agent:
+  1. Calls GetEntityObservations(entityId=..., entityType=...) — retrieves ALL observations
+  2. Observations include photos: [{photo_url, photo_description, transcription}]
+  3. LLM structures the formal report per the template
+  4. Incorporates user's supplemental context ("4 hours", "come back twice") under Complainant's Statement
+    │
+    ▼
+Response is a structured markdown report:
+  - # Rights Violation Report
+  - Photos as ![caption](url) — inline evidence
+  - Violations table
+  - Filing instructions (ARTA online portal, etc.)
+    │
+    ▼
+Response streamed to client
+```
+
+### Photo Data Flow Detail
+
+```
+GetEntityObservations response:
+{
+  observations: [
+    {
+      id: "obs-123",
+      text: "Waited 2.5 hours, only 1 window open",
+      photos: [
+        {
+          photo_url: "https://d2xyz.cloudfront.net/orgs/xxx/photos/abc.jpg",
+          photo_description: "Single service window with 40+ people in queue",
+          transcription: null
+        }
+      ],
+      created_at: "2026-06-28T09:15:00Z"
+    }
+  ]
+}
+    │
+    ▼
+Maxwell renders in response:
+"**2026-06-28 — Long wait at SSS Sapian**
+Waited 2.5 hours with only 1 window open despite 40+ people in queue.
+
+![Single service window with 40+ people in queue](https://d2xyz.cloudfront.net/orgs/xxx/photos/abc.jpg)
+*Photo evidence: Only one service window was operational during peak hours.*"
+```
+
+## 5. Rich Copy Behavior
+
+**No changes needed.** The existing `copyConversationRich()` infrastructure handles everything:
+
+### Flow When User Clicks "Copy Conversation"
+
+```
+Maxwell response (markdown with images)
+    │
+    ▼
+copyConversationRich(messages)
+    │
+    ├─ conversationToHtml(messages)
+    │   └─ Converts ![alt](url) → <img src="url" alt="alt" style="..." />
+    │   └─ Converts **bold** → <strong>bold</strong>
+    │   └─ Converts headers, lists, etc. to HTML
+    │
+    ├─ Writes to clipboard as ClipboardItem:
+    │   ├─ text/html: Full HTML with <img> tags (renders in Gmail, Google Docs, ChatGPT)
+    │   └─ text/plain: Raw markdown with ![alt](url) links preserved
+    │
+    ▼
+User pastes into:
+  - Gmail/Google Docs → Images render inline ✓
+  - Web forms (ARTA portal) → Plain text with URLs ✓
+  - ChatGPT → Images render inline ✓
+```
+
+### Why This Works for Rights Violation Reports
+
+1. **Photos as evidence**: The report contains `![caption](photo_url)` which becomes `<img>` in rich paste — recipient sees the evidence inline
+2. **CloudFront URLs**: Photos use full CloudFront URLs (not signed/expiring), so they remain accessible to the recipient
+3. **Structured format**: Headers, tables, and bold formatting all survive the HTML conversion
+4. **Plain text fallback**: If pasting into a plain-text form, the URLs are still present as clickable links
+
+## 6. Implementation Scope
+
+### Files to Create
+
+| File | Purpose |
+|------|---------|
+| `lambda/ws-maxwell-worker/prompts/sonnet46/rights.txt` | Rights mode prompt (content in Section 3) |
+| `lambda/maxwell-chat/prompts/sonnet46/rights.txt` | Same file, copied for REST-based Maxwell |
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `lambda/ws-maxwell-worker/index.js` | Add `RIGHTS_PROMPT` loading, `RIGHTS_KEYWORDS` regex, update `detectPromptMode()` |
+| `lambda/maxwell-chat/index.js` | Same changes as ws-maxwell-worker |
+
+### Exact Code Changes
+
+#### `lambda/ws-maxwell-worker/index.js`
+
+**Add after existing prompt loading (line ~30):**
+```javascript
+const RIGHTS_PROMPT = loadPrompt('rights.txt');
+```
+
+**Add after existing keyword regexes (line ~35):**
+```javascript
+const RIGHTS_KEYWORDS = /\b(rights?|file|report|complain(t|ts)?|violat(e|ed|ion|ions)|charter|consumer|accountability|escalat(e|ion)|who do i report|arta|dti|npc|dole|ntc|due process|red tape|anti.?red.?tape|citizen.?s?.?charter|refund|return policy|labor (code|law|rights)|tenant.?s?.?rights?|landlord)\b/i;
+```
+
+**Update `detectPromptMode` function:**
+```javascript
+function detectPromptMode(message) {
+  if (RIGHTS_PROMPT && RIGHTS_KEYWORDS.test(message)) return RIGHTS_PROMPT;
+  if (STORAGE_PROMPT && STORAGE_KEYWORDS.test(message)) return STORAGE_PROMPT;
+  if (QUANTITATIVE_PROMPT && QUANTITATIVE_KEYWORDS.test(message)) return QUANTITATIVE_PROMPT;
+  return GENERAL_PROMPT;
+}
+```
+
+#### `lambda/maxwell-chat/index.js`
+
+Identical changes to the three items above.
+
+### Deployment
+
+After implementation, deploy both Lambdas using the fast deployment script:
+
+```bash
+./scripts/deploy/deploy-lambda-fast.sh ws-maxwell-worker ws-maxwell-worker
+./scripts/deploy/deploy-lambda-fast.sh maxwell-chat maxwell-chat-lambda
+```
+
+Note: Since this only adds a `.txt` file and modifies `index.js` (no new npm dependencies), fast deployment is sufficient.
+
+## 7. Example Interactions
+
+### Example 1: Proactive Mode
+
+**User prompt:** "What are my rights when transacting at SSS?"
+
+**Detected by:** `rights` matches `RIGHTS_KEYWORDS`
+
+**Expected Maxwell response:**
+
+> **Your Rights: SSS Transactions**
+>
+> **Applicable Framework**
+> - Anti-Red Tape Act (RA 11032) — all government frontline services
+> - SSS Citizens' Charter — specific processing time commitments
+>
+> **What You're Entitled To**
+> - **Processing time**: Simple transactions (ID validation, contribution inquiry) must be completed within **3 working days**. Complex transactions within **7 working days**.
+> - **Single-window service**: You should NOT be required to visit multiple offices for a single transaction
+> - **No fixing**: No employee may demand payment beyond official fees
+> - **Posted fees and timelines**: The Citizens' Charter must be visibly displayed
+> - **First-come-first-served**: Unless a priority lane system is posted
+>
+> **If They Don't Comply**
+> - **File with ARTA**: [arta.gov.ph](https://arta.gov.ph) → Report a Concern
+> - **Contact Center ng Bayan**: Call 8888 (landline) or text 0908-881-6565
+> - **Response time**: ARTA must act within 7 working days of receiving complaint
+>
+> **Practical Tips**
+> - Photo the Citizens' Charter display (or its absence)
+> - Note the time you arrive and the time you're served
+> - Get the name of the attending employee (check their ID or desk nameplate)
+> - Keep all queue numbers and receipts
+
+### Example 2: Evaluative Mode
+
+**User prompt:** "Were my rights violated at SSS today? Look at my observations."
+
+**Context:** Entity "SSS Sapian Visit" is selected in Maxwell panel
+
+**Detected by:** `rights` and `violated` match `RIGHTS_KEYWORDS`
+
+**Expected Maxwell response:**
+
+> **Rights Assessment: SSS Sapian Visit**
+>
+> **Applicable Standard**
+> - Anti-Red Tape Act (RA 11032): Simple transactions ≤ 3 working days; no unnecessary requirements
+> - SSS Citizens' Charter: Contribution payment processing ≤ 20 minutes
+>
+> **What Happened (from your observations)**
+>
+> **2026-06-28, 9:15 AM** — Arrived at SSS Sapian. Only 1 window operational despite 40+ people in queue.
+>
+> ![Single window with long queue](https://d2xyz.cloudfront.net/photos/abc.jpg)
+>
+> **2026-06-28, 11:45 AM** — Finally served after 2.5 hours. Told payment system is offline, asked to "come back tomorrow."
+>
+> ![System offline notice](https://d2xyz.cloudfront.net/photos/def.jpg)
+>
+> **Assessment**
+> - ❌ **Processing time (≤ 20 min for contributions)**: Violated — 2.5-hour wait, then transaction not completed
+> - ❌ **No unnecessary return visits**: Violated — told to return the next day due to system issue (their system, not your obligation)
+> - ❌ **Adequate service capacity**: Violated — only 1 window open during peak hours for 40+ clients
+> - ✅ **Posted Citizens' Charter**: Met — charter was displayed (visible in photo)
+>
+> **Conclusion**
+> Based on 2 documented observations with photo evidence, 3 of 4 applicable standards were not met. The 2.5-hour wait alone exceeds the Citizens' Charter commitment by 7.5x.
+>
+> **If You Want to Escalate**
+> Your evidence is strong — timestamped observations with photos. You can file with ARTA via arta.gov.ph. Would you like me to generate a formal Rights Violation Report?
+
+### Example 3: Report Mode
+
+**User prompt:** "Generate a report against SSS Sapian. I spent 4 hours total across 2 visits and they still haven't processed my contribution payment."
+
+**Context:** Entity "SSS Sapian Visit" is selected
+
+**Detected by:** `report` matches `RIGHTS_KEYWORDS`
+
+**Expected Maxwell response:**
+
+> # Rights Violation Report
+>
+> **Filed Against:** Social Security System (SSS) — Sapian, Capiz Branch
+> **Complainant:** [Organization member name from context]
+> **Date of Report:** 2026-06-30
+> **Period Covered:** 2026-06-28 to 2026-06-29
+>
+> ## Applicable Rights & Standards
+>
+> 1. **Republic Act 11032** (Anti-Red Tape Act of 2018)
+>    - §9: Processing time for simple transactions shall not exceed 3 working days
+>    - §7: No unnecessary requirements or steps shall be imposed
+>    - §10: Government offices must maintain adequate staffing for frontline services
+>
+> 2. **SSS Citizens' Charter**
+>    - Contribution payment processing: ≤ 20 minutes
+>    - System availability: Service windows must be operational during posted hours
+>
+> ## Timeline of Events
+>
+> **2026-06-28, 9:15 AM — First Visit**
+> Arrived at SSS Sapian. Only 1 service window operational with 40+ people ahead in queue.
+>
+> ![Single service window with 40+ people in queue](https://d2xyz.cloudfront.net/photos/abc.jpg)
+> *Photo evidence: Inadequate service capacity — one window for 40+ clients*
+>
+> **2026-06-28, 11:45 AM — Service Denied**
+> After 2.5 hours of waiting, informed that the payment system is offline. Instructed to return the next day.
+>
+> ![System offline notice on counter](https://d2xyz.cloudfront.net/photos/def.jpg)
+> *Photo evidence: System offline notice; transaction could not be completed*
+>
+> **2026-06-29, 8:30 AM — Second Visit**
+> Returned as instructed. Queue already at 25+ people.
+>
+> ![Morning queue at SSS](https://d2xyz.cloudfront.net/photos/ghi.jpg)
+> *Photo evidence: Significant queue on return visit*
+>
+> ## Violations Identified
+>
+> | # | Standard/Provision | Requirement | What Happened | Evidence |
+> |---|---|---|---|---|
+> | 1 | RA 11032 §9 | Simple transaction ≤ 3 working days | Transaction incomplete after 2 visits across 2 days | Observations 2026-06-28, 2026-06-29 |
+> | 2 | SSS Charter | Processing ≤ 20 minutes | 2.5-hour wait, then denied service | Photo: queue + offline notice |
+> | 3 | RA 11032 §10 | Adequate staffing | 1 window for 40+ clients | Photo: single operational window |
+> | 4 | RA 11032 §7 | No unnecessary steps | Required to make a second visit due to their system failure | Observation 2026-06-28 |
+>
+> ## Complainant's Statement
+>
+> Complainant states: "I spent 4 hours total across 2 visits and they still haven't processed my contribution payment."
+>
+> *Note: Total time expenditure (4 hours) is self-reported by complainant across both documented visits.*
+>
+> ## Supporting Evidence Summary
+>
+> - **Documented observations:** 3 entries with timestamps
+> - **Photo evidence:** 3 photos
+> - **Period documented:** 2026-06-28 to 2026-06-29
+>
+> ## Recommended Filing
+>
+> **Oversight Body:** Anti-Red Tape Authority (ARTA)
+> **How to File:**
+> - Online: https://arta.gov.ph — "Report a Concern" → select SSS
+> - Hotline: Contact Center ng Bayan — call 8888 or text 0908-881-6565
+> - Email: complaints@arta.gov.ph
+> **Expected Response Time:** ARTA must act within 7 working days (RA 11032 §21)
+>
+> ---
+> *This report was generated from documented observations with photo evidence. Copy and paste into the ARTA online portal or email to complaints@arta.gov.ph.*
+
+### Example 4: Ambiguous Intent (Defaults to Proactive)
+
+**User prompt:** "Lazada consumer protection"
+
+**Detected by:** `consumer` matches `RIGHTS_KEYWORDS`
+
+**Expected Maxwell response:**
+
+Maxwell responds in proactive mode (explaining rights under DTI consumer protection for e-commerce), then asks: "Would you like me to evaluate a specific Lazada experience, or generate a report if your rights were violated?"
+
+### Example 5: Report Mode with Date Filtering
+
+**User prompt:** "Generate a report about my Lazada dispute from last week"
+
+**Detected by:** `report` matches `RIGHTS_KEYWORDS`
+
+**Expected behavior:** Bedrock Agent calls `GetEntityObservations` with `dateFrom` set to 7 days ago. The report covers only observations from that period.
+
+## 8. Edge Cases & Fallback Behavior
+
+| Scenario | Behavior |
+|----------|----------|
+| Rights keywords match but user is asking about storage ("Where do I file my reports?") | `RIGHTS_KEYWORDS` takes priority. However, "file" in the context of "where do I file my reports" would trigger rights mode. The word "file" is intentionally in the regex because filing complaints is core to the skill. If the user is genuinely asking about physical file storage, the LLM should recognize from context and respond appropriately — the tone/general prompts instruct Maxwell to follow what the question actually needs. |
+| No entity context and user asks for evaluation | Prompt instructs Maxwell to inform the user: "I don't see any logged observations. Would you like me to explain your rights, or can you point me to the entity where you logged your experience?" |
+| User asks about non-Philippine jurisdiction | Prompt defaults to Philippine law but adapts if user specifies another country (e.g., "What are my consumer rights in the US?") |
+| Keyword "refund" triggers rights mode for a simple financial question | The regex priority (rights before quantitative) means "How much is my SSS refund?" would route to rights mode. This is acceptable because refund inquiries typically are rights-related. If it becomes problematic, the regex can be narrowed. |
+
+## 9. Testing Plan
+
+### Manual Testing (Post-Deploy)
+
+1. **Proactive mode**: Send "What are my rights at SSS?" — verify structured rights response without tool calls
+2. **Evaluative mode**: Open an entity with observations, send "Were my rights violated?" — verify GetEntityObservations is called and assessment is returned
+3. **Report mode**: Same entity, send "Generate a rights violation report" — verify full report format with photos
+4. **Fallback to general**: Send "What's the weather?" — verify rights mode is NOT triggered
+5. **Rich copy**: Copy a report with photos, paste into Gmail — verify images render inline
+6. **Date filtering**: "Generate a report from last week" — verify date parameters passed to GetEntityObservations
+
+### Keyword Regression
+
+Verify these do NOT trigger rights mode:
+- "Store the file cabinet in the shed" → should trigger storage (or general)
+- "How much did we spend this month?" → should trigger quantitative (or general)
+
+Verify these DO trigger rights mode:
+- "What are my rights?"
+- "File a complaint"
+- "Generate a report against SSS"
+- "Was my consumer protection violated?"
+- "ARTA red tape"

--- a/.kiro/specs/maxwell-know-your-rights/requirements.md
+++ b/.kiro/specs/maxwell-know-your-rights/requirements.md
@@ -1,0 +1,102 @@
+# Requirements Document
+
+## Introduction
+
+The "Know Your Rights" Maxwell skill empowers users to understand their rights in any situation where another party has obligations to them — whether a government agency, e-commerce platform, telco, employer, landlord, or financial institution. The skill operates in three modes depending on user intent: proactive (what are my rights?), evaluative (were my rights violated?), and action (generate a Rights Violation Report with evidence). It leverages the LLM's knowledge of laws, regulations, consumer protection standards, and platform policies, and connects to the user's logged observations when building evidence-based cases.
+
+## Glossary
+
+- **Rights Context**: The situation-specific set of laws, regulations, standards, contracts, or policies that define what a user is entitled to from a counterparty
+- **Counterparty**: Any entity with obligations to the user — government agency, seller, employer, service provider, landlord, platform, etc.
+- **Observation**: A recorded state (text + optional photos + optional metrics) linked to an entity in CWF, representing a logged interaction or event
+- **Rights Violation Report**: A structured, factual document presenting evidence that the user's rights were violated, intended for submission to the appropriate oversight body for adjudication
+- **Oversight Body**: The entity with authority to adjudicate or enforce — e.g., ARTA for red tape, DTI for consumer issues, NPC for data privacy, DOLE for labor, NTC for telcos, courts for civil matters
+- **Maxwell Skill**: A prompt-driven capability within Maxwell that is triggered by user intent detection and shapes the response format
+
+## Requirements
+
+### Requirement 1: Proactive Rights Awareness
+
+**User Story:** As a user about to engage with a counterparty (government agency, seller, service provider, etc.), I want to ask Maxwell what my rights are in that situation, so that I know what to expect and can identify violations as they happen.
+
+**Acceptance Criteria:**
+
+1. WHEN a user asks about their rights in a given situation (e.g., "What are my rights at SSS?", "What should I expect when disputing a Lazada order?", "What does my landlord owe me?"), THE System SHALL detect the rights-awareness intent
+2. THE System SHALL respond with the relevant legal/regulatory/contractual framework that applies to the user's situation
+3. THE System SHALL include practical details: processing time commitments, required documents, applicable fees, escalation paths
+4. THE System SHALL NOT require the user to have logged observations — this mode works from situation description alone
+5. THE System SHALL identify the jurisdiction and applicable laws (Philippine law by default given the user base, but adaptable if the user specifies otherwise)
+
+### Requirement 2: Evaluative Mode — Were My Rights Violated?
+
+**User Story:** As a user who has interacted with a counterparty and logged observations, I want Maxwell to evaluate whether my rights were violated based on my recorded experience, so that I can make an informed decision about whether to escalate.
+
+**Acceptance Criteria:**
+
+1. WHEN a user asks Maxwell to evaluate their experience (e.g., "Were my rights violated at SSS today?", "Did Lazada follow the return policy?", "Look at my SSS interactions and tell me if there's a case"), THE System SHALL detect the evaluative intent
+2. THE System SHALL pull observations from the referenced entity using the existing `GetEntityObservations` tool
+3. THE System SHALL compare the observed experience against the applicable rights framework (laws, charter, platform policy)
+4. THE System SHALL clearly state which specific rights or standards were violated, and which were met
+5. THE System SHALL present its assessment factually — stating what the standard requires vs. what happened — without rendering a legal judgment
+6. WHEN no violations are identified, THE System SHALL inform the user and explain why the experience appears compliant
+
+### Requirement 3: Rights Violation Report Generation
+
+**User Story:** As a user whose rights were violated, I want Maxwell to generate a Rights Violation Report from my observations and photos, so that I can submit it to the appropriate oversight body for adjudication.
+
+**Acceptance Criteria:**
+
+1. WHEN a user requests a Rights Violation Report (e.g., "Generate a report against SSS", "Help me file about my Lazada dispute", "I want to report this"), THE System SHALL detect the report-generation intent
+2. THE System SHALL pull observations (with photos) from the referenced entity, applying date filters if the user specifies a time range
+3. THE report SHALL include: counterparty identified, applicable rights/standards, specific violations with evidence, chronological timeline from observations, photo evidence as links with captions, the appropriate oversight body and filing method
+4. THE report SHALL format photos as markdown links so they render in the Maxwell panel and survive rich copy: `![caption](photo_url)`
+5. THE report SHALL be structured so the user can copy-paste it (via existing rich copy) into an email, web form, or ChatGPT for final modification
+6. THE System SHALL clearly label which oversight body the report should be directed to and how to submit it (online portal URL, email address, physical office if applicable)
+
+### Requirement 4: Skill Detection & Prompt Routing
+
+**User Story:** As the system, I need to detect when a user's message relates to rights awareness, evaluation, or report generation, so that Maxwell applies the correct prompt mode and response format.
+
+**Acceptance Criteria:**
+
+1. THE System SHALL detect rights-related intent via keyword patterns (e.g., "rights", "file", "report", "complain", "violated", "charter", "consumer", "accountability", "escalate", "who do I report to")
+2. WHEN rights-related intent is detected, THE System SHALL prepend a prompt instruction block that guides Maxwell to respond in the appropriate mode (proactive, evaluative, or report)
+3. THE System SHALL determine the mode from context: proactive when no observations are referenced, evaluative when the user asks for assessment, report when the user requests a document for filing
+4. THE System SHALL follow the existing prompt-mode pattern used by storage, quantitative, and general modes in the Maxwell worker lambda
+5. WHEN intent is ambiguous, THE System SHALL default to proactive mode (inform the user of their rights) and ask if they'd like an evaluation or report
+
+### Requirement 5: No New Infrastructure Required
+
+**User Story:** As a developer, I want this skill to work within the existing Maxwell architecture, so that it can be shipped without new Lambda functions, API endpoints, or database changes.
+
+**Acceptance Criteria:**
+
+1. THE skill SHALL be implemented as a new prompt mode in the existing `ws-maxwell-worker` lambda (and/or `maxwell-chat` lambda), following the same pattern as storage/quantitative/general modes
+2. THE skill SHALL use the existing `GetEntityObservations` tool (with its date filtering) to retrieve evidence — no new action groups required
+3. THE skill SHALL use the existing `UnifiedSearch` tool when additional context is needed (e.g., searching for related observations across entities)
+4. THE skill SHALL NOT require storing Citizens' Charter or legal reference data locally — it relies on the LLM's training knowledge
+5. THE skill SHALL use the existing rich copy infrastructure (`copyConversationRich`) for output — no new frontend components required
+6. THE skill SHALL NOT require new API endpoints, Lambda functions, database tables, or Bedrock Agent action groups
+
+### Requirement 6: Supplemental User Context
+
+**User Story:** As a user generating a Rights Violation Report, I want to be able to add context that wasn't captured in my observations (e.g., total time wasted, number of visits, verbal interactions), so that the report reflects the full picture.
+
+**Acceptance Criteria:**
+
+1. WHEN generating a report, THE System SHALL incorporate any additional context provided in the user's prompt (e.g., "I spent 4 hours", "they made me come back 3 times", "the guard told me to come back tomorrow")
+2. THE System SHALL distinguish between evidence from logged observations (with timestamps/photos) and user-stated context (verbal claims without documentation)
+3. THE report SHALL label user-stated context appropriately (e.g., "Complainant states:" vs. evidence with photo/timestamp references)
+
+### Requirement 7: Rich Copy with Inline Evidence
+
+**User Story:** As a user who has generated a Rights Violation Report, I want to copy the complete report (text + photo evidence) so I can paste it into emails, web forms, or ChatGPT with images preserved inline.
+
+**Acceptance Criteria:**
+
+1. WHEN a user copies the Maxwell response containing a Rights Violation Report, THE System SHALL use the existing rich copy mechanism (HTML + plain text clipboard)
+2. THE rich copy SHALL include photos as `<img>` tags so they render inline when pasted into rich-text destinations (Gmail, Google Docs, ChatGPT)
+3. THE plain text fallback SHALL include photo URLs as clickable links with descriptive captions so the report remains useful in plain-text destinations (web forms, ARTA portal)
+4. THE System SHALL use the existing "Copy conversation" button in the Maxwell panel — no new UI required
+5. WHEN photos are referenced in the report, THE System SHALL use the full CloudFront/S3 URL so images are accessible to the recipient
+

--- a/.kiro/specs/maxwell-know-your-rights/tasks.md
+++ b/.kiro/specs/maxwell-know-your-rights/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: Maxwell "Know Your Rights" Skill
+
+## Implementation Tasks
+
+### Task 1: Create rights.txt prompt file ✅
+- [x] Create `lambda/ws-maxwell-worker/prompts/sonnet46/rights.txt`
+- [x] Prompt covers all three modes: proactive, evaluative, report
+- [x] Copy to `lambda/maxwell-chat/prompts/sonnet46/rights.txt`
+
+### Task 2: Update Lambda keyword detection ✅
+- [x] Add `RIGHTS_PROMPT = loadPrompt('rights.txt')` to both Lambdas
+- [x] Add `RIGHTS_KEYWORDS` regex before storage/quantitative detection
+- [x] Update `detectPromptMode()` to check rights first in both Lambdas
+- [x] Files modified: `lambda/ws-maxwell-worker/index.js`, `lambda/maxwell-chat/index.js`
+
+### Task 3: Deploy ✅
+- [x] Deploy ws-maxwell-worker: `./scripts/deploy/deploy-lambda-fast.sh ws-maxwell-worker cwf-ws-maxwell-worker`
+- [x] Deploy maxwell-chat: `./scripts/deploy/deploy-lambda-fast.sh maxwell-chat cwf-maxwell-chat-lambda`
+
+## Testing Checklist
+
+- [ ] **Proactive mode**: "What are my rights at SSS?" → structured rights response without tool calls
+- [ ] **Evaluative mode**: Open entity with observations → "Were my rights violated?" → assessment with photos
+- [ ] **Report mode**: "Generate a rights violation report" → full report format with evidence
+- [ ] **No false positives**: "Where do I store the file cabinet?" → triggers storage, not rights
+- [ ] **Rich copy**: Copy a report with photos, paste into Gmail → images render inline
+- [ ] **Date filtering**: "Generate a report from last week" → date params passed to GetEntityObservations
+
+## Implementation Notes
+
+- `RIGHTS_KEYWORDS` uses `file a` instead of bare `file` to avoid triggering on storage queries like "where do I file this"
+- Rights detection takes priority over storage and quantitative (checked first in `detectPromptMode()`)
+- Sub-mode detection (proactive vs evaluative vs report) is handled by the LLM within the prompt, not by separate regexes
+- No new infrastructure: no new Lambdas, endpoints, tables, or Bedrock action groups
+- `GetEntityObservations` already supports `dateFrom`/`dateTo` parameters — no backend changes needed

--- a/.kiro/specs/maxwell-qa-persistence/design.md
+++ b/.kiro/specs/maxwell-qa-persistence/design.md
@@ -1,0 +1,579 @@
+# Design: Maxwell Q&A Persistence
+
+## 1. Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ SAVE FLOW                                                               │
+│                                                                         │
+│  Frontend                    ws-message-router         ws-maxwell-worker │
+│  ─────────                   ────────────────          ──────────────── │
+│  User asks question  ──WS──▸ Extracts auth context ──▸ Invokes Bedrock │
+│  (includes page_url          Adds userId to event       Agent           │
+│   in payload)                                           │               │
+│                                                         ▼               │
+│                                                   Response complete     │
+│                                                         │               │
+│                                                         ├──▸ postToConnection (reply)
+│                                                         │               │
+│                                                         ▼               │
+│                                                   saveInteraction()     │
+│                                                   (fire-and-forget)     │
+│                                                         │               │
+│                                                         ├──▸ INSERT states
+│                                                         ├──▸ INSERT state_links (if entity context)
+│                                                         └──▸ SQS → embedding queue
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│ FETCH FLOW                                                              │
+│                                                                         │
+│  Frontend                         API Gateway           cwf-core-lambda │
+│  ─────────                        ───────────           ────────────── │
+│  Maxwell panel opens ──GET──▸ /api/maxwell/questions ──▸ Query states  │
+│  (sends page_url)                                       WHERE type =    │
+│                                                         maxwell_interaction
+│           ◂── JSON array of { id, question } ──────────┘ AND page_url  │
+│                                                           AND user_id   │
+│                                                           AND !deleted  │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│ DELETE FLOW                                                             │
+│                                                                         │
+│  Frontend                         API Gateway           cwf-core-lambda │
+│  ─────────                        ───────────           ────────────── │
+│  User clicks X ──────DELETE──▸ /api/maxwell/questions/:id ──▸ UPDATE   │
+│                                                               state_text│
+│                                                         (set deleted_at)│
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Data Model
+
+Maxwell interactions are stored as rows in the existing `states` table. The `state_text` column contains a JSON string:
+
+```json
+{
+  "type": "maxwell_interaction",
+  "question": "What tools do we have for metalworking?",
+  "response": "Based on the inventory, you have...",
+  "model": "deep",
+  "input_tokens": 1523,
+  "output_tokens": 847,
+  "duration_ms": 34200,
+  "page_url": "/actions/abc-123",
+  "deleted_at": null
+}
+```
+
+The state row uses:
+- `captured_by` → user who asked the question (cognito_user_id)
+- `organization_id` → user's org (from authorizer)
+- `captured_at` → timestamp when the question was asked
+
+If entity context existed (entityType + entityId in sessionAttributes), a `state_links` row links the state to that entity.
+
+---
+
+## 2. Backend: Save Interaction
+
+### Location
+
+The save happens in `lambda/ws-maxwell-worker/index.js` immediately after `postToConnection` sends the `maxwell:response_complete` message. It's wrapped in a try/catch so failures don't affect the user experience.
+
+### Getting user_id into the worker
+
+Currently the `maxwellChatHandler` passes `{ connectionId, payload, endpoint, organizationId }` to the worker. We add `userId` (the `cognito_user_id` from the WebSocket authorizer context):
+
+```javascript
+// lambda/ws-message-router/maxwellChatHandler.js
+const authContext = event.requestContext.authorizer || {};
+const organizationId = authContext.organization_id;
+const userId = authContext.cognito_user_id; // ADD THIS
+
+// In the InvokeCommand payload:
+Payload: JSON.stringify({
+  connectionId,
+  payload,
+  endpoint,
+  organizationId,
+  userId,  // ADD THIS
+}),
+```
+
+### Getting page_url into the worker
+
+The frontend sends `page_url` alongside the existing `sessionAttributes` in the WebSocket message payload:
+
+```javascript
+// Frontend sends:
+wsSendMessage('maxwell:chat', {
+  message: enhancedText,
+  sessionId,
+  mode,
+  history,
+  page_url: window.location.pathname,  // ADD THIS
+  sessionAttributes: { ... },
+});
+```
+
+The `page_url` flows through: frontend → ws-message-router → ws-maxwell-worker (via `payload.page_url`).
+
+### Token extraction from trace
+
+Token usage is available in Bedrock Agent trace events. The worker already collects `traceEvents[]`. After the streaming loop completes, extract tokens:
+
+```javascript
+function extractTokenUsage(traceEvents) {
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  for (const event of traceEvents) {
+    const usage = event.trace?.orchestrationTrace?.modelInvocationOutput?.metadata?.usage;
+    if (usage) {
+      inputTokens += usage.inputTokens || 0;
+      outputTokens += usage.outputTokens || 0;
+    }
+  }
+
+  return { inputTokens, outputTokens };
+}
+```
+
+### Save implementation
+
+After the `postToConnection` call for `maxwell:response_complete`, add:
+
+```javascript
+// Fire-and-forget: save interaction to states table
+saveInteraction({
+  organizationId,
+  userId: event.userId,
+  question: message,       // original user message (without mode prefix/instructions)
+  response: reply,
+  model: mode,
+  inputTokens: tokenUsage.inputTokens,
+  outputTokens: tokenUsage.outputTokens,
+  durationMs: tEnd - t0,
+  pageUrl: payload.page_url || null,
+  entityType: sessionAttributes.entityType || null,
+  entityId: sessionAttributes.entityId || null,
+}).catch(err => console.error('[MAXWELL-WORKER] Failed to save interaction:', err.message));
+```
+
+### saveInteraction function
+
+```javascript
+const { getDbClient } = require('/opt/nodejs/db');
+const { SQSClient, SendMessageCommand } = require('@aws-sdk/client-sqs');
+const { composeStateEmbeddingSource } = require('/opt/nodejs/embedding-composition');
+
+const sqs = new SQSClient({ region: 'us-west-2' });
+const EMBEDDINGS_QUEUE_URL = 'https://sqs.us-west-2.amazonaws.com/131745734428/cwf-embeddings-queue';
+
+async function saveInteraction({ organizationId, userId, question, response, model, inputTokens, outputTokens, durationMs, pageUrl, entityType, entityId }) {
+  const client = await getDbClient();
+  try {
+    await client.query('BEGIN');
+
+    const stateText = JSON.stringify({
+      type: 'maxwell_interaction',
+      question,
+      response,
+      model,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      duration_ms: durationMs,
+      page_url: pageUrl,
+      deleted_at: null,
+    });
+
+    const stateResult = await client.query(`
+      INSERT INTO states (organization_id, state_text, captured_by, captured_at)
+      VALUES ($1, $2, $3::uuid, NOW())
+      RETURNING id
+    `, [organizationId, stateText, userId]);
+
+    const stateId = stateResult.rows[0].id;
+
+    // Link to entity if context exists
+    if (entityType && entityId) {
+      await client.query(`
+        INSERT INTO state_links (state_id, entity_type, entity_id)
+        VALUES ($1, $2, $3::uuid)
+      `, [stateId, entityType, entityId]);
+    }
+
+    await client.query('COMMIT');
+
+    // Queue embedding generation (after commit)
+    const embeddingSource = composeStateEmbeddingSource({
+      entity_names: [],
+      state_text: stateText,
+      photo_descriptions: [],
+      metrics: [],
+    });
+
+    if (embeddingSource && embeddingSource.trim()) {
+      await sqs.send(new SendMessageCommand({
+        QueueUrl: EMBEDDINGS_QUEUE_URL,
+        MessageBody: JSON.stringify({
+          entity_type: 'state',
+          entity_id: stateId,
+          embedding_source: embeddingSource,
+          organization_id: organizationId,
+        }),
+      }));
+    }
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+```
+
+### Infrastructure requirement
+
+The `cwf-ws-maxwell-worker` Lambda currently does NOT have the `cwf-common-nodejs` layer attached (it only has `@aws-sdk/client-bedrock-agent-runtime` and `@aws-sdk/client-apigatewaymanagementapi` as local deps). To use `getDbClient()` and `composeStateEmbeddingSource()`, the layer must be attached.
+
+**Action required:** Run deploy with layer:
+```bash
+./scripts/deploy/deploy-lambda-with-layer.sh ws-maxwell-worker cwf-ws-maxwell-worker
+```
+
+The Lambda also needs:
+- `DB_PASSWORD` environment variable (for RDS connection via the layer's `db.js`)
+- VPC configuration (same subnet/security group as other DB-accessing Lambdas)
+
+---
+
+## 3. Backend: Fetch Starter Questions
+
+### Endpoint
+
+```
+GET /api/maxwell/questions?page_url=/actions/abc-123
+```
+
+### Handler location
+
+Add a new route in `cwf-core-lambda` (or create a small dedicated `cwf-maxwell-questions` Lambda). Given the simplicity, adding to `cwf-core-lambda` with a route check is preferred.
+
+**Alternative considered:** Adding as a query filter to the existing `GET /api/states` endpoint. Rejected because the states endpoint is heavy (joins photos, perspectives, metrics) and the maxwell query needs only `id` + `question` text.
+
+### Query
+
+```sql
+SELECT
+  s.id,
+  s.state_text,
+  s.captured_at
+FROM states s
+WHERE s.organization_id = $1
+  AND s.captured_by = $2::uuid
+  AND s.state_text::jsonb->>'type' = 'maxwell_interaction'
+  AND s.state_text::jsonb->>'page_url' = $3
+  AND (s.state_text::jsonb->>'deleted_at') IS NULL
+ORDER BY s.captured_at DESC
+LIMIT 5
+```
+
+### Response shape
+
+```json
+[
+  {
+    "id": "uuid-of-state",
+    "question": "What tools do we have for metalworking?",
+    "captured_at": "2026-06-30T10:15:00Z"
+  },
+  ...
+]
+```
+
+The handler parses `state_text` JSON and returns only the `question` field (the full response text is not needed for starter display).
+
+### Authorization
+
+Standard: `organization_id` from authorizer context, `user_id` from authorizer (`cognito_user_id`). Only the user's own questions are returned (Requirement 3.5).
+
+---
+
+## 4. Backend: Soft Delete
+
+### Endpoint
+
+```
+DELETE /api/maxwell/questions/:id
+```
+
+### Implementation
+
+```sql
+-- First verify ownership
+SELECT state_text FROM states
+WHERE id = $1
+  AND organization_id = $2
+  AND captured_by = $3::uuid
+
+-- Then update the JSON to add deleted_at
+UPDATE states
+SET state_text = jsonb_set(
+  state_text::jsonb,
+  '{deleted_at}',
+  to_jsonb(NOW()::text)
+)::text,
+updated_at = NOW()
+WHERE id = $1
+```
+
+### Response
+
+```json
+{ "success": true }
+```
+
+### Authorization
+
+Standard org + user check. A user can only soft-delete their own interactions (verified by `captured_by = userId`).
+
+---
+
+## 5. Embedding Composition Change
+
+### Problem
+
+When `composeStateEmbeddingSource` receives a maxwell_interaction state, the `state_text` is a JSON string containing metadata (tokens, model, page_url, duration_ms) that would pollute the semantic search signal.
+
+### Solution
+
+Modify `composeStateEmbeddingSource` in `lambda/layers/cwf-common-nodejs/nodejs/embedding-composition.js` to detect maxwell_interaction JSON and extract only `question` + `response`:
+
+```javascript
+function composeStateEmbeddingSource(state) {
+  const parts = [];
+
+  if (state.entity_names && state.entity_names.length > 0) {
+    parts.push(...state.entity_names);
+  }
+
+  if (state.state_text) {
+    // Detect maxwell_interaction JSON and extract only Q&A text
+    const extracted = extractMaxwellText(state.state_text);
+    if (extracted) {
+      parts.push(extracted);
+    } else {
+      parts.push(state.state_text);
+    }
+  }
+
+  if (state.photo_descriptions && state.photo_descriptions.length > 0) {
+    parts.push(...state.photo_descriptions);
+  }
+
+  if (state.metrics && state.metrics.length > 0) {
+    for (const m of state.metrics) {
+      const metricStr = m.unit
+        ? `${m.display_name}: ${m.value} ${m.unit}`
+        : `${m.display_name}: ${m.value}`;
+      parts.push(metricStr);
+    }
+  }
+
+  return parts.filter(Boolean).join('. ');
+}
+
+/**
+ * If state_text is a maxwell_interaction JSON string, extract only question + response.
+ * Returns the extracted text or null if not a maxwell_interaction.
+ */
+function extractMaxwellText(stateText) {
+  // Quick check before parsing (avoid JSON.parse on every state)
+  if (!stateText.includes('"maxwell_interaction"')) return null;
+
+  try {
+    const parsed = JSON.parse(stateText);
+    if (parsed.type === 'maxwell_interaction') {
+      const textParts = [];
+      if (parsed.question) textParts.push(parsed.question);
+      if (parsed.response) textParts.push(parsed.response);
+      return textParts.join('. ') || null;
+    }
+  } catch {
+    // Not valid JSON — treat as plain text
+  }
+  return null;
+}
+```
+
+### Why this approach
+
+- **Backward compatible**: Non-JSON `state_text` (normal observations) passes through unchanged.
+- **Fast path**: The `includes('"maxwell_interaction"')` check avoids `JSON.parse` on the majority of states that are plain text.
+- **Semantic signal**: Only the question and response carry meaning for search. Metadata like `input_tokens: 1523` or `page_url: "/actions/abc"` adds noise.
+
+---
+
+## 6. Frontend Changes
+
+### 6.1 useMaxwell.ts — Pass page_url
+
+In the `sendMessage` callback where `wsSendMessage` is called, add `page_url`:
+
+```typescript
+wsSendMessage('maxwell:chat', {
+  message: enhancedText,
+  sessionId: sessionId ?? undefined,
+  mode,
+  history,
+  page_url: window.location.pathname,  // ADD
+  sessionAttributes: { ... },
+});
+```
+
+No other changes to `useMaxwell.ts`.
+
+### 6.2 New hook: useMaxwellStarterQuestions.ts
+
+```typescript
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiService } from '@/lib/apiService';
+
+interface SavedQuestion {
+  id: string;
+  question: string;
+  captured_at: string;
+}
+
+export function useMaxwellStarterQuestions(pageUrl: string | null) {
+  const queryClient = useQueryClient();
+
+  const { data: savedQuestions = [], isLoading } = useQuery({
+    queryKey: ['maxwell-questions', pageUrl],
+    queryFn: async () => {
+      const result = await apiService.get<SavedQuestion[]>(
+        `/maxwell/questions?page_url=${encodeURIComponent(pageUrl!)}`
+      );
+      return result;
+    },
+    enabled: !!pageUrl,
+    staleTime: 60_000, // 1 minute — starter questions don't change fast
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (questionId: string) => {
+      await apiService.delete(`/maxwell/questions/${questionId}`);
+    },
+    onSuccess: (_, questionId) => {
+      // Optimistically remove from cache
+      queryClient.setQueryData<SavedQuestion[]>(
+        ['maxwell-questions', pageUrl],
+        (old) => old?.filter(q => q.id !== questionId) ?? []
+      );
+    },
+  });
+
+  return {
+    savedQuestions,
+    isLoading,
+    deleteQuestion: deleteMutation.mutate,
+  };
+}
+```
+
+### 6.3 GlobalMaxwellPanel.tsx — Starter questions section
+
+Replace the hardcoded starter questions logic with:
+
+```typescript
+import { useMaxwellStarterQuestions } from '@/hooks/useMaxwellStarterQuestions';
+
+// Inside the component:
+const pageUrl = window.location.pathname;
+const { savedQuestions, deleteQuestion } = useMaxwellStarterQuestions(pageUrl);
+
+// Determine which questions to show
+const starterQuestions = savedQuestions.length > 0
+  ? savedQuestions
+  : getHardcodedStarters(activeContext?.entityType);
+```
+
+Render saved questions with a delete button:
+
+```tsx
+{messages.length === 0 && !isLoading && (
+  <div className="space-y-2 pt-2">
+    {savedQuestions.length > 0
+      ? savedQuestions.map((q) => (
+          <div key={q.id} className="relative group/starter">
+            <button
+              onClick={() => sendMessage(q.question, maxwellMode)}
+              disabled={isLoading}
+              className="w-full rounded-xl border border-border bg-muted/50 px-4 py-2.5 pr-8 text-left text-sm text-foreground hover:bg-muted transition-colors"
+            >
+              {q.question}
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); deleteQuestion(q.id); }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full opacity-0 group-hover/starter:opacity-100 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-all"
+              aria-label="Remove saved question"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        ))
+      : hardcodedStarters.map((q) => (
+          <button
+            key={q}
+            onClick={() => sendMessage(q, maxwellMode)}
+            disabled={isLoading}
+            className="w-full rounded-xl border border-border bg-muted/50 px-4 py-2.5 text-left text-sm text-foreground hover:bg-muted transition-colors"
+          >
+            {q}
+          </button>
+        ))
+    }
+  </div>
+)}
+```
+
+### 6.4 Fetch timing
+
+The `useMaxwellStarterQuestions` hook fires when `pageUrl` is set (always truthy). TanStack Query handles caching — subsequent opens of the Maxwell panel on the same page use cached data with a 60-second stale time.
+
+---
+
+## 7. Implementation Scope
+
+### Files to modify
+
+| File | Change |
+|------|--------|
+| `lambda/ws-message-router/maxwellChatHandler.js` | Pass `userId` (from `authContext.cognito_user_id`) in the worker invocation payload |
+| `lambda/ws-maxwell-worker/index.js` | Add `saveInteraction()` function, call after response_complete, add token extraction, import DB/SQS from layer |
+| `lambda/ws-maxwell-worker/package.json` | No new dependencies needed (DB + SQS come from the layer) |
+| `lambda/layers/cwf-common-nodejs/nodejs/embedding-composition.js` | Add `extractMaxwellText()` helper, update `composeStateEmbeddingSource()` |
+| `lambda/core/index.js` (or new route handler) | Add `GET /api/maxwell/questions` and `DELETE /api/maxwell/questions/:id` handlers |
+| `src/hooks/useMaxwell.ts` | Add `page_url: window.location.pathname` to WebSocket payload |
+| `src/hooks/useMaxwellStarterQuestions.ts` | **New file** — hook for fetching/deleting saved questions |
+| `src/components/GlobalMaxwellPanel.tsx` | Replace hardcoded starters with saved questions + delete button, fallback to hardcoded |
+
+### Infrastructure / deployment steps
+
+1. Attach `cwf-common-nodejs` layer to `cwf-ws-maxwell-worker` Lambda
+2. Add `DB_PASSWORD` env var to `cwf-ws-maxwell-worker`
+3. Add VPC config (same subnet/SG as `cwf-core-lambda`) to `cwf-ws-maxwell-worker`
+4. Add API Gateway routes: `GET /api/maxwell/questions`, `DELETE /api/maxwell/questions/{id}` with authorizer
+5. Deploy API Gateway changes
+
+### What is NOT needed
+
+- No new database tables or columns
+- No new Lambda functions (reuse core + worker)
+- No schema migrations
+- No changes to the SQS queue or embeddings processor
+- No changes to the WebSocket authorizer

--- a/.kiro/specs/maxwell-qa-persistence/requirements.md
+++ b/.kiro/specs/maxwell-qa-persistence/requirements.md
@@ -1,0 +1,63 @@
+# Requirements Document
+
+## Introduction
+
+The Maxwell Q&A Persistence feature saves all Maxwell interactions (questions and responses) to the backend so that valuable insights aren't lost across sessions, and usage/cost can be tracked. Saved interactions are surfaced as starter questions in the Maxwell panel, replacing the current hardcoded suggestions with real questions previously asked.
+
+## Glossary
+
+- **Interaction**: A single question-response pair from a Maxwell conversation
+- **Starter Questions**: The clickable question buttons shown when Maxwell has no active conversation — currently hardcoded, to be replaced with saved interactions
+- **Usage Metadata**: Token counts (input/output) and duration that enable cost estimation
+
+## Requirements
+
+### Requirement 1: Persist Maxwell Q&A Server-Side
+
+**User Story:** As a user, I want my Maxwell questions and responses saved to the backend with usage metadata, so that valuable insights aren't lost and I can estimate costs.
+
+**Acceptance Criteria:**
+
+1. WHEN Maxwell returns a completed response, THE System SHALL save the interaction to the backend
+2. THE saved record SHALL include: question text, response text, user_id, timestamp, model used (quick/deep), input_tokens, output_tokens, and duration_ms
+3. THE System SHALL save automatically on response completion — no manual action required
+4. THE System SHALL continue to function if the save fails (fire-and-forget, non-blocking)
+5. THE save SHALL be initiated from the frontend after the response is received
+
+### Requirement 2: Surface Past Questions as Starter Questions
+
+**User Story:** As a user opening Maxwell, I want to see questions I previously asked, so that I can quickly re-ask valuable questions or continue a previous line of inquiry.
+
+**Acceptance Criteria:**
+
+1. WHEN the Maxwell panel opens with no active conversation, THE System SHALL display recent questions the user previously asked (instead of or in addition to hardcoded starters)
+2. THE System SHALL show the most recent questions first (up to a reasonable limit, e.g., 5)
+3. WHEN a user clicks a saved starter question, THE System SHALL send that question to Maxwell as if the user typed it
+4. WHEN no saved questions exist, THE System SHALL fall back to the existing hardcoded starter questions
+5. THE System SHALL scope saved questions to the user within their current organization (user + org pair)
+
+### Requirement 3: Delete Saved Interactions
+
+**User Story:** As a user who accidentally asked something sensitive, I want to hide a saved interaction, so that it doesn't appear as a starter question, while still preserving the record for cost tracking.
+
+**Acceptance Criteria:**
+
+1. WHEN viewing saved starter questions, THE System SHALL display a delete button (e.g., X icon) on each question
+2. WHEN a user clicks delete, THE System SHALL soft-delete the interaction (set a `deleted_at` timestamp)
+3. THE System SHALL NOT display soft-deleted interactions as starter questions
+4. THE System SHALL NOT require confirmation for deletion (quick action, low risk)
+5. A user SHALL only be able to see and delete their own saved interactions
+6. Soft-deleted records SHALL remain in the database for cost tracking and analytics purposes
+
+### Requirement 4: Storage in States Table with Selective Embedding
+
+**User Story:** As a system, I want Maxwell interactions stored in the existing states table as JSON, with the embedding processor extracting only the Q&A text for search, so that metadata doesn't pollute the semantic signal.
+
+**Acceptance Criteria:**
+
+1. THE System SHALL store Maxwell interactions as rows in the `states` table with `state_text` containing a JSON object
+2. THE JSON object SHALL include: `type` ("maxwell_interaction"), `question`, `response`, `model`, `input_tokens`, `output_tokens`, `duration_ms`, `deleted_at`
+3. THE state row SHALL use `captured_by` for the user_id and `organization_id` for org scoping
+4. THE System SHALL link the state to the relevant entity via `state_links` if entity context was present when the question was asked
+5. THE embedding processor SHALL detect `state_text` containing `"type": "maxwell_interaction"`, parse the JSON, and compose the embedding source from only `question` + `response` text (excluding model, tokens, duration, and other metadata)
+6. THE `deleted_at` field in the JSON SHALL be used for soft-delete (set to ISO timestamp when user deletes)

--- a/lambda/core/index.js
+++ b/lambda/core/index.js
@@ -6341,6 +6341,125 @@ exports.handler = async (event) => {
       return { statusCode: 200, headers, body: JSON.stringify({ shared: rows }) };
     }
 
+    // ========== MAXWELL INTERACTIONS ==========
+
+    if (path === '/maxwell/interactions' || path.match(/\/maxwell\/interactions\/[a-f0-9-]+$/)) {
+      const userId = authContext.cognito_user_id;
+
+      // POST /maxwell/interactions — save a new interaction
+      if (httpMethod === 'POST' && path === '/maxwell/interactions') {
+        const body = typeof event.body === 'string' ? JSON.parse(event.body) : event.body;
+        const { question, response, model, input_tokens, output_tokens, duration_ms, entity_type, entity_id } = body;
+
+        if (!question || !response) {
+          return { statusCode: 400, headers, body: JSON.stringify({ error: 'question and response are required' }) };
+        }
+
+        const stateText = JSON.stringify({
+          type: 'maxwell_interaction',
+          question,
+          response,
+          model: model || null,
+          input_tokens: input_tokens || null,
+          output_tokens: output_tokens || null,
+          duration_ms: duration_ms || null,
+          deleted_at: null,
+        });
+
+        const client = await getDbClient();
+        try {
+          await client.query('BEGIN');
+
+          const stateResult = await client.query(
+            `INSERT INTO states (organization_id, state_text, captured_by, captured_at)
+             VALUES ($1, $2, $3::uuid, NOW())
+             RETURNING id`,
+            [organizationId, stateText, userId]
+          );
+          const stateId = stateResult.rows[0].id;
+
+          if (entity_type && entity_id) {
+            await client.query(
+              `INSERT INTO state_links (state_id, entity_type, entity_id)
+               VALUES ($1, $2, $3::uuid)`,
+              [stateId, entity_type, entity_id]
+            );
+          }
+
+          await client.query('COMMIT');
+
+          // Queue embedding (fire-and-forget)
+          sqs.send(new SendMessageCommand({
+            QueueUrl: EMBEDDINGS_QUEUE_URL,
+            MessageBody: JSON.stringify({
+              entity_type: 'state',
+              entity_id: stateId,
+              embedding_source: `${question}. ${response}`,
+              organization_id: organizationId,
+            }),
+          })).catch(err => console.error('Failed to queue maxwell interaction embedding:', err.message));
+
+          return { statusCode: 201, headers, body: JSON.stringify({ id: stateId }) };
+        } catch (err) {
+          await client.query('ROLLBACK').catch(() => {});
+          throw err;
+        } finally {
+          client.release();
+        }
+      }
+
+      // GET /maxwell/interactions — fetch recent starter questions
+      if (httpMethod === 'GET' && path === '/maxwell/interactions') {
+        const userId = authContext.cognito_user_id;
+        const rows = await queryJSON(
+          `SELECT s.id, s.state_text, s.captured_at
+           FROM states s
+           WHERE s.organization_id = $1
+             AND s.captured_by = $2::uuid
+             AND s.state_text LIKE '%"maxwell_interaction"%'
+             AND (s.state_text::jsonb->>'deleted_at') IS NULL
+           ORDER BY s.captured_at DESC
+           LIMIT 5`,
+          [organizationId, userId]
+        );
+
+        const questions = rows.map(row => {
+          try {
+            const parsed = JSON.parse(row.state_text);
+            return { id: row.id, question: parsed.question, captured_at: row.captured_at };
+          } catch {
+            return null;
+          }
+        }).filter(Boolean);
+
+        return { statusCode: 200, headers, body: JSON.stringify(questions) };
+      }
+
+      // DELETE /maxwell/interactions/:id — soft delete
+      if (httpMethod === 'DELETE' && path.match(/\/maxwell\/interactions\/[a-f0-9-]+$/)) {
+        const interactionId = path.split('/').pop();
+        const userId = authContext.cognito_user_id;
+
+        const result = await queryJSON(
+          `UPDATE states
+           SET state_text = jsonb_set(state_text::jsonb, '{deleted_at}', to_jsonb(NOW()::text))::text,
+               updated_at = NOW()
+           WHERE id = $1
+             AND organization_id = $2
+             AND captured_by = $3::uuid
+             AND state_text LIKE '%"maxwell_interaction"%'
+           RETURNING id`,
+          [interactionId, organizationId, userId]
+        );
+
+        if (result.length === 0) {
+          return { statusCode: 404, headers, body: JSON.stringify({ error: 'Not found or not yours' }) };
+        }
+
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+      }
+    }
+
     // Default 404
     return {
       statusCode: 404,

--- a/lambda/core/index.js
+++ b/lambda/core/index.js
@@ -6417,7 +6417,6 @@ exports.handler = async (event) => {
            WHERE s.organization_id = $1
              AND s.captured_by = $2::uuid
              AND s.state_text LIKE '%"maxwell_interaction"%'
-             AND (s.state_text::jsonb->>'deleted_at') IS NULL
            ORDER BY s.captured_at DESC
            LIMIT 5`,
           [organizationId, userId]
@@ -6426,7 +6425,7 @@ exports.handler = async (event) => {
         const questions = rows.map(row => {
           try {
             const parsed = JSON.parse(row.state_text);
-            return { id: row.id, question: parsed.question, captured_at: row.captured_at };
+            return { id: row.id, question: parsed.question, response: parsed.response, captured_at: row.captured_at };
           } catch {
             return null;
           }
@@ -6435,28 +6434,51 @@ exports.handler = async (event) => {
         return { statusCode: 200, headers, body: JSON.stringify(questions) };
       }
 
-      // DELETE /maxwell/interactions/:id — soft delete
+      // DELETE /maxwell/interactions/:id — hard delete
       if (httpMethod === 'DELETE' && path.match(/\/maxwell\/interactions\/[a-f0-9-]+$/)) {
         const interactionId = path.split('/').pop();
         const userId = authContext.cognito_user_id;
 
-        const result = await queryJSON(
-          `UPDATE states
-           SET state_text = jsonb_set(state_text::jsonb, '{deleted_at}', to_jsonb(NOW()::text))::text,
-               updated_at = NOW()
-           WHERE id = $1
-             AND organization_id = $2
-             AND captured_by = $3::uuid
-             AND state_text LIKE '%"maxwell_interaction"%'
-           RETURNING id`,
-          [interactionId, organizationId, userId]
-        );
+        const client = await getDbClient();
+        try {
+          await client.query('BEGIN');
 
-        if (result.length === 0) {
-          return { statusCode: 404, headers, body: JSON.stringify({ error: 'Not found or not yours' }) };
+          // Delete from unified_embeddings first (FK or related)
+          await client.query(
+            `DELETE FROM unified_embeddings WHERE entity_type = 'state' AND entity_id = $1`,
+            [interactionId]
+          );
+
+          // Delete state_links
+          await client.query(
+            `DELETE FROM state_links WHERE state_id = $1`,
+            [interactionId]
+          );
+
+          // Delete the state itself (only if owned by user + org + is a maxwell_interaction)
+          const result = await client.query(
+            `DELETE FROM states
+             WHERE id = $1
+               AND organization_id = $2
+               AND captured_by = $3::uuid
+               AND state_text LIKE '%"maxwell_interaction"%'
+             RETURNING id`,
+            [interactionId, organizationId, userId]
+          );
+
+          await client.query('COMMIT');
+
+          if (result.rows.length === 0) {
+            return { statusCode: 404, headers, body: JSON.stringify({ error: 'Not found or not yours' }) };
+          }
+
+          return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+        } catch (err) {
+          await client.query('ROLLBACK').catch(() => {});
+          throw err;
+        } finally {
+          client.release();
         }
-
-        return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
       }
     }
 

--- a/lambda/layers/cwf-common-nodejs/nodejs/embedding-composition.js
+++ b/lambda/layers/cwf-common-nodejs/nodejs/embedding-composition.js
@@ -196,7 +196,12 @@ function composeStateEmbeddingSource(state) {
   }
 
   if (state.state_text) {
-    parts.push(state.state_text);
+    const extracted = extractMaxwellText(state.state_text);
+    if (extracted) {
+      parts.push(extracted);
+    } else {
+      parts.push(state.state_text);
+    }
   }
 
   if (state.photo_descriptions && state.photo_descriptions.length > 0) {
@@ -213,6 +218,27 @@ function composeStateEmbeddingSource(state) {
   }
 
   return parts.filter(Boolean).join('. ');
+}
+
+/**
+ * If state_text is a maxwell_interaction JSON string, extract only question + response.
+ * Returns the extracted text or null if not a maxwell_interaction.
+ */
+function extractMaxwellText(stateText) {
+  if (!stateText.includes('"maxwell_interaction"')) return null;
+
+  try {
+    const parsed = JSON.parse(stateText);
+    if (parsed.type === 'maxwell_interaction') {
+      const textParts = [];
+      if (parsed.question) textParts.push(parsed.question);
+      if (parsed.response) textParts.push(parsed.response);
+      return textParts.join('. ') || null;
+    }
+  } catch {
+    // Not valid JSON — treat as plain text
+  }
+  return null;
 }
 
 /**
@@ -251,5 +277,6 @@ module.exports = {
   composeIssueEmbeddingSource,
   composePolicyEmbeddingSource,
   composeStateEmbeddingSource,
-  composeFinancialRecordEmbeddingSource
+  composeFinancialRecordEmbeddingSource,
+  extractMaxwellText
 };

--- a/lambda/maxwell-chat/index.js
+++ b/lambda/maxwell-chat/index.js
@@ -26,7 +26,9 @@ const TONE_PROMPT = loadPrompt('tone.txt');
 const STORAGE_PROMPT = loadPrompt('storage.txt');
 const QUANTITATIVE_PROMPT = loadPrompt('quantitative.txt');
 const GENERAL_PROMPT = loadPrompt('general.txt');
+const RIGHTS_PROMPT = loadPrompt('rights.txt');
 
+const RIGHTS_KEYWORDS = /\b(rights?|file a|report|complain(t|ts)?|violat(e|ed|ion|ions)|charter|consumer|accountability|escalat(e|ion)|who do i report|arta|dti|npc|dole|ntc|due process|red tape|anti.?red.?tape|citizen.?s?.?charter|refund|return policy|labor (code|law|rights)|tenant.?s?.?rights?|landlord)\b/i;
 const STORAGE_KEYWORDS = /\b(store|storage|where.*put|where.*keep|organize|location|shelf|shed|toolbox|cabinet)\b/i;
 const QUANTITATIVE_KEYWORDS = /\b(roi|cost|revenue|profit|price|expense|budget|investment|how much|per month|per day|per week|earnings|income|margin|break.?even|spend|spent|purchase|purchased|bought|transaction|payment|balance)\b/i;
 
@@ -34,6 +36,7 @@ const QUANTITATIVE_KEYWORDS = /\b(roi|cost|revenue|profit|price|expense|budget|i
  * Detect question type and return the appropriate prompt fragment.
  */
 function detectPromptMode(message) {
+  if (RIGHTS_PROMPT && RIGHTS_KEYWORDS.test(message)) return RIGHTS_PROMPT;
   if (STORAGE_PROMPT && STORAGE_KEYWORDS.test(message)) return STORAGE_PROMPT;
   if (QUANTITATIVE_PROMPT && QUANTITATIVE_KEYWORDS.test(message)) return QUANTITATIVE_PROMPT;
   return GENERAL_PROMPT;

--- a/lambda/maxwell-chat/prompts/sonnet46/rights.txt
+++ b/lambda/maxwell-chat/prompts/sonnet46/rights.txt
@@ -1,0 +1,128 @@
+The user is asking about their rights in relation to a counterparty (government agency, seller, employer, service provider, landlord, telco, platform, etc.).
+
+Determine which mode applies based on the user's message and available context:
+
+---
+
+MODE 1: PROACTIVE (Rights Awareness)
+Trigger: The user asks what their rights are in a situation, OR asks what to expect. No assessment of a past event is requested.
+
+Use this response format:
+
+**Your Rights: [Situation]**
+
+**Applicable Framework**
+- Name the specific law, regulation, charter, or policy that applies (e.g., "Anti-Red Tape Act (RA 11032)", "DTI Consumer Act (RA 7394)", "Lazada Return & Refund Policy")
+- Jurisdiction: Philippines unless user specifies otherwise
+
+**What You're Entitled To**
+- Each specific right or standard, with concrete details (processing times, fees, required documents)
+- Use bullet points, bold the key obligation
+
+**If They Don't Comply**
+- Escalation path: which oversight body, how to file, contact details if known
+- Timeline: how long they have to respond to a complaint
+
+**Practical Tips**
+- What to document (photos, names, timestamps) in case you need to escalate later
+
+---
+
+MODE 2: EVALUATIVE (Were My Rights Violated?)
+Trigger: The user asks Maxwell to assess whether their rights were violated based on their experience. Entity observations are typically available.
+
+First, call GetEntityObservations to retrieve the user's logged experience. If the user mentions a date range, use dateFrom/dateTo parameters.
+
+Use this response format:
+
+**Rights Assessment: [Entity/Counterparty]**
+
+**Applicable Standard**
+- The specific law/charter/policy and what it requires
+
+**What Happened (from your observations)**
+- Chronological summary drawn from observations, citing dates and details
+- Include photos inline: ![description](url)
+
+**Assessment**
+For each relevant standard:
+- ✅ **[Standard]**: Met — [brief explanation]
+- ❌ **[Standard]**: Violated — [what the standard requires vs. what happened]
+
+**Conclusion**
+- Clear factual statement: "Based on [N] documented interactions, [X] of [Y] applicable standards were not met."
+- If no violations found: "Your experience appears compliant with [framework]. Here's why: [explanation]"
+
+**If You Want to Escalate**
+- Which oversight body has jurisdiction
+- Whether the evidence is sufficient (photos, timestamps, documented interactions)
+- What additional documentation would strengthen a case
+
+---
+
+MODE 3: REPORT (Rights Violation Report Generation)
+Trigger: The user explicitly asks for a report, wants to file a complaint, or says "generate a report", "help me file", "I want to report this".
+
+First, call GetEntityObservations to retrieve ALL observations (with photos). Use dateFrom/dateTo if the user specifies a period. If no entity context exists, ask the user which entity contains their evidence.
+
+Use this response format:
+
+# Rights Violation Report
+
+**Filed Against:** [Counterparty name and branch/location if known]
+**Complainant:** [From organization context — do not ask unless unavailable]
+**Date of Report:** [Today's date]
+**Period Covered:** [Date range of observations]
+
+## Applicable Rights & Standards
+
+[List each applicable law, regulation, charter commitment, or policy with its specific relevant provisions. Cite section numbers where possible.]
+
+## Timeline of Events
+
+[Chronological account drawn from observations. Each entry:]
+
+**[Date] — [Summary]**
+[Details from observation text]
+
+![Photo description](photo_url)
+*[Caption explaining what the photo shows as evidence]*
+
+[Repeat for each relevant observation]
+
+## Violations Identified
+
+| # | Standard/Provision | Requirement | What Happened | Evidence |
+|---|---|---|---|---|
+| 1 | [e.g., RA 11032 §9] | [What it requires] | [What actually happened] | [Date, photo ref] |
+
+## Complainant's Statement
+
+[Include any additional context the user provided in their prompt that isn't in the observations. Label clearly: "Complainant states: ..."]
+
+## Supporting Evidence Summary
+
+- **Documented observations:** [count] entries with timestamps
+- **Photo evidence:** [count] photos
+- **Period documented:** [first date] to [last date]
+
+## Recommended Filing
+
+**Oversight Body:** [e.g., ARTA, DTI, NPC, DOLE, NTC, or relevant court]
+**How to File:**
+- Online: [portal URL if known]
+- Email: [address if known]
+- In person: [office location if known]
+**Expected Response Time:** [statutory timeframe if applicable]
+
+---
+
+IMPORTANT RULES FOR ALL MODES:
+- Default jurisdiction: Philippines. Adapt if the user mentions another country.
+- Use your training knowledge for laws, charters, and policies. Do NOT claim you need to look up a database — you know Philippine consumer protection law, ARTA, labor code, etc.
+- When referencing observations, always use data from GetEntityObservations. Never fabricate observation content.
+- Display ALL photos from observations inline as ![description](url) — these are critical evidence.
+- When no observations are available and the user is in evaluative/report mode, inform them: "I don't see any logged observations for this entity. Would you like me to explain your rights (proactive mode), or can you point me to the entity where you logged your experience?"
+- In report mode, distinguish between documented evidence (observations with timestamps/photos) and user-stated claims (verbal context provided in the prompt). Label user-stated claims as "Complainant states:" in the report.
+- Be factual and precise. State what the standard requires vs. what happened. Do NOT render legal judgments (e.g., don't say "they are liable"). State facts and let the oversight body adjudicate.
+- When the user provides supplemental context in their message (e.g., "I spent 4 hours", "they made me come back 3 times"), incorporate it in the report under "Complainant's Statement" — clearly marked as unverified user-reported context.

--- a/lambda/maxwell-observations/index.js
+++ b/lambda/maxwell-observations/index.js
@@ -342,6 +342,8 @@ exports.handler = async (event) => {
   }
 
   const { dateFrom, dateTo } = params;
+  const limit = params.limit ? parseInt(params.limit, 10) : null;
+  const DEFAULT_LIMIT = 10;
 
   if (!entityId) {
     return buildActionGroupResponse(actionGroup, apiPath, httpMethod, 400, {
@@ -375,8 +377,18 @@ exports.handler = async (event) => {
     }
     const dateFilterClause = dateFilters.length > 0 ? `AND ${dateFilters.join(' AND ')}` : '';
 
+    // When date filters are provided, return all matching observations (no limit).
+    // When no date filters, apply a limit (default 10) to control LLM context costs.
+    // User can also pass an explicit limit parameter to override.
+    const hasDateFilter = dateFilters.length > 0;
+    const effectiveLimit = hasDateFilter ? null : (limit || DEFAULT_LIMIT);
+
+    // If limiting, fetch most recent N (DESC) then reverse for chronological output
+    const orderClause = effectiveLimit ? 'ORDER BY s.captured_at DESC' : 'ORDER BY s.captured_at ASC';
+    const limitClause = effectiveLimit ? `LIMIT ${effectiveLimit}` : '';
+
     const sql = `
-      SELECT COALESCE(json_agg(row_to_json(t)), '[]'::json) AS json_agg
+      SELECT COALESCE(json_agg(row_to_json(t) ORDER BY t.observed_at ASC), '[]'::json) AS json_agg
       FROM (
         SELECT
           s.state_text          AS observation_text,
@@ -428,7 +440,8 @@ exports.handler = async (event) => {
           AND sl.entity_id::text      = '${escapeLiteral(entityId)}'
           AND s.organization_id::text = '${escapeLiteral(organizationId)}'
           ${dateFilterClause}
-        ORDER BY s.captured_at ASC
+        ${orderClause}
+        ${limitClause}
       ) t;
     `;
 

--- a/lambda/organization/index.js
+++ b/lambda/organization/index.js
@@ -326,13 +326,14 @@ exports.handler = async (event) => {
         [cognitoUserId, cognitoUserId, email, organizationId, role]
       );
 
-      // Generate invite token and send email (non-blocking — membership is already created)
+      // Generate invite token and link
+      const token = generateInviteToken(email, organizationId);
+      const appUrl = process.env.APP_URL || 'https://stargazer-farm.com';
+      const inviteLink = `${appUrl}/accept-invite?token=${token}`;
+
+      // Attempt to send email via SES (best-effort — may fail in sandbox mode)
       let emailSent = false;
       try {
-        const token = generateInviteToken(email, organizationId);
-        const appUrl = process.env.APP_URL || 'https://stargazer-farm.com';
-        const inviteLink = `${appUrl}/accept-invite?token=${token}`;
-
         await ses.send(new SendEmailCommand({
           Source: process.env.SES_FROM_EMAIL || 'noreply@stargazer-farm.com',
           Destination: { ToAddresses: [email] },
@@ -355,7 +356,7 @@ exports.handler = async (event) => {
         console.warn('Failed to send invite email:', emailErr.message);
       }
 
-      return { statusCode: 200, headers, body: JSON.stringify({ success: true, cognitoUserId, emailSent }) };
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, cognitoUserId, emailSent, inviteLink }) };
     }
 
     // POST /api/validate-invite-token — validates a JWT invite token

--- a/lambda/ws-maxwell-worker/index.js
+++ b/lambda/ws-maxwell-worker/index.js
@@ -55,8 +55,10 @@ const TONE_PROMPT = loadPrompt('tone.txt');
 const STORAGE_PROMPT = loadPrompt('storage.txt');
 const QUANTITATIVE_PROMPT = loadPrompt('quantitative.txt');
 const GENERAL_PROMPT = loadPrompt('general.txt');
+const RIGHTS_PROMPT = loadPrompt('rights.txt');
 
 // --- Keyword detection (same as maxwell-chat) ---
+const RIGHTS_KEYWORDS = /\b(rights?|file a|report|complain(t|ts)?|violat(e|ed|ion|ions)|charter|consumer|accountability|escalat(e|ion)|who do i report|arta|dti|npc|dole|ntc|due process|red tape|anti.?red.?tape|citizen.?s?.?charter|refund|return policy|labor (code|law|rights)|tenant.?s?.?rights?|landlord)\b/i;
 const STORAGE_KEYWORDS = /\b(store|storage|where.*put|where.*keep|organize|location|shelf|shed|toolbox|cabinet)\b/i;
 const QUANTITATIVE_KEYWORDS = /\b(roi|cost|revenue|profit|price|expense|budget|investment|how much|per month|per day|per week|earnings|income|margin|break.?even|spend|spent|purchase|purchased|bought|transaction|payment|balance)\b/i;
 
@@ -64,6 +66,7 @@ const QUANTITATIVE_KEYWORDS = /\b(roi|cost|revenue|profit|price|expense|budget|i
  * Detect question type and return the appropriate prompt fragment.
  */
 function detectPromptMode(message) {
+  if (RIGHTS_PROMPT && RIGHTS_KEYWORDS.test(message)) return RIGHTS_PROMPT;
   if (STORAGE_PROMPT && STORAGE_KEYWORDS.test(message)) return STORAGE_PROMPT;
   if (QUANTITATIVE_PROMPT && QUANTITATIVE_KEYWORDS.test(message)) return QUANTITATIVE_PROMPT;
   return GENERAL_PROMPT;

--- a/lambda/ws-maxwell-worker/index.js
+++ b/lambda/ws-maxwell-worker/index.js
@@ -352,11 +352,25 @@ exports.handler = async (event) => {
 
     // Send the final complete response
     // We send a filtered lightweightTrace instead of the full trace array to stay under the 128 KB limit.
+    // Extract token usage from trace events
+    let inputTokens = 0;
+    let outputTokens = 0;
+    for (const t of traceEvents) {
+      const usage = t.trace?.orchestrationTrace?.modelInvocationOutput?.metadata?.usage;
+      if (usage) {
+        inputTokens += usage.inputTokens || 0;
+        outputTokens += usage.outputTokens || 0;
+      }
+    }
+
     await postToConnection(apiGwClient, connectionId, buildEnvelope('maxwell:response_complete', {
       reply,
       sessionId: returnedSessionId || effectiveSessionId,
       traceCount: traceEvents.length,
       trace: lightweightTrace,
+      inputTokens,
+      outputTokens,
+      durationMs: tEnd - t0,
     }));
   } catch (err) {
     console.error('[MAXWELL-WORKER] Bedrock Agent error:', err);

--- a/lambda/ws-maxwell-worker/prompts/sonnet46/rights.txt
+++ b/lambda/ws-maxwell-worker/prompts/sonnet46/rights.txt
@@ -1,0 +1,128 @@
+The user is asking about their rights in relation to a counterparty (government agency, seller, employer, service provider, landlord, telco, platform, etc.).
+
+Determine which mode applies based on the user's message and available context:
+
+---
+
+MODE 1: PROACTIVE (Rights Awareness)
+Trigger: The user asks what their rights are in a situation, OR asks what to expect. No assessment of a past event is requested.
+
+Use this response format:
+
+**Your Rights: [Situation]**
+
+**Applicable Framework**
+- Name the specific law, regulation, charter, or policy that applies (e.g., "Anti-Red Tape Act (RA 11032)", "DTI Consumer Act (RA 7394)", "Lazada Return & Refund Policy")
+- Jurisdiction: Philippines unless user specifies otherwise
+
+**What You're Entitled To**
+- Each specific right or standard, with concrete details (processing times, fees, required documents)
+- Use bullet points, bold the key obligation
+
+**If They Don't Comply**
+- Escalation path: which oversight body, how to file, contact details if known
+- Timeline: how long they have to respond to a complaint
+
+**Practical Tips**
+- What to document (photos, names, timestamps) in case you need to escalate later
+
+---
+
+MODE 2: EVALUATIVE (Were My Rights Violated?)
+Trigger: The user asks Maxwell to assess whether their rights were violated based on their experience. Entity observations are typically available.
+
+First, call GetEntityObservations to retrieve the user's logged experience. If the user mentions a date range, use dateFrom/dateTo parameters.
+
+Use this response format:
+
+**Rights Assessment: [Entity/Counterparty]**
+
+**Applicable Standard**
+- The specific law/charter/policy and what it requires
+
+**What Happened (from your observations)**
+- Chronological summary drawn from observations, citing dates and details
+- Include photos inline: ![description](url)
+
+**Assessment**
+For each relevant standard:
+- ✅ **[Standard]**: Met — [brief explanation]
+- ❌ **[Standard]**: Violated — [what the standard requires vs. what happened]
+
+**Conclusion**
+- Clear factual statement: "Based on [N] documented interactions, [X] of [Y] applicable standards were not met."
+- If no violations found: "Your experience appears compliant with [framework]. Here's why: [explanation]"
+
+**If You Want to Escalate**
+- Which oversight body has jurisdiction
+- Whether the evidence is sufficient (photos, timestamps, documented interactions)
+- What additional documentation would strengthen a case
+
+---
+
+MODE 3: REPORT (Rights Violation Report Generation)
+Trigger: The user explicitly asks for a report, wants to file a complaint, or says "generate a report", "help me file", "I want to report this".
+
+First, call GetEntityObservations to retrieve ALL observations (with photos). Use dateFrom/dateTo if the user specifies a period. If no entity context exists, ask the user which entity contains their evidence.
+
+Use this response format:
+
+# Rights Violation Report
+
+**Filed Against:** [Counterparty name and branch/location if known]
+**Complainant:** [From organization context — do not ask unless unavailable]
+**Date of Report:** [Today's date]
+**Period Covered:** [Date range of observations]
+
+## Applicable Rights & Standards
+
+[List each applicable law, regulation, charter commitment, or policy with its specific relevant provisions. Cite section numbers where possible.]
+
+## Timeline of Events
+
+[Chronological account drawn from observations. Each entry:]
+
+**[Date] — [Summary]**
+[Details from observation text]
+
+![Photo description](photo_url)
+*[Caption explaining what the photo shows as evidence]*
+
+[Repeat for each relevant observation]
+
+## Violations Identified
+
+| # | Standard/Provision | Requirement | What Happened | Evidence |
+|---|---|---|---|---|
+| 1 | [e.g., RA 11032 §9] | [What it requires] | [What actually happened] | [Date, photo ref] |
+
+## Complainant's Statement
+
+[Include any additional context the user provided in their prompt that isn't in the observations. Label clearly: "Complainant states: ..."]
+
+## Supporting Evidence Summary
+
+- **Documented observations:** [count] entries with timestamps
+- **Photo evidence:** [count] photos
+- **Period documented:** [first date] to [last date]
+
+## Recommended Filing
+
+**Oversight Body:** [e.g., ARTA, DTI, NPC, DOLE, NTC, or relevant court]
+**How to File:**
+- Online: [portal URL if known]
+- Email: [address if known]
+- In person: [office location if known]
+**Expected Response Time:** [statutory timeframe if applicable]
+
+---
+
+IMPORTANT RULES FOR ALL MODES:
+- Default jurisdiction: Philippines. Adapt if the user mentions another country.
+- Use your training knowledge for laws, charters, and policies. Do NOT claim you need to look up a database — you know Philippine consumer protection law, ARTA, labor code, etc.
+- When referencing observations, always use data from GetEntityObservations. Never fabricate observation content.
+- Display ALL photos from observations inline as ![description](url) — these are critical evidence.
+- When no observations are available and the user is in evaluative/report mode, inform them: "I don't see any logged observations for this entity. Would you like me to explain your rights (proactive mode), or can you point me to the entity where you logged your experience?"
+- In report mode, distinguish between documented evidence (observations with timestamps/photos) and user-stated claims (verbal context provided in the prompt). Label user-stated claims as "Complainant states:" in the report.
+- Be factual and precise. State what the standard requires vs. what happened. Do NOT render legal judgments (e.g., don't say "they are liable"). State facts and let the oversight body adjudicate.
+- When the user provides supplemental context in their message (e.g., "I spent 4 hours", "they made me come back 3 times"), incorporate it in the report under "Complainant's Statement" — clearly marked as unverified user-reported context.

--- a/src/components/GlobalMaxwellFAB.tsx
+++ b/src/components/GlobalMaxwellFAB.tsx
@@ -13,16 +13,23 @@ export function GlobalMaxwellFAB() {
   const location = useLocation();
   const isDashboard = location.pathname === '/' || location.pathname === '/dashboard';
   const isFinances = location.pathname === '/finances';
+  const isObservations = location.pathname === '/observations' || location.pathname.startsWith('/observations/');
 
   // Listen for open-maxwell events from other components (e.g. Dashboard header button)
   useEffect(() => {
-    const handleOpen = () => setIsPanelOpen(true);
+    const handleOpen = (e: Event) => {
+      const customEvent = e as CustomEvent;
+      if (customEvent.detail?.context) {
+        setCurrentContext(customEvent.detail.context);
+      }
+      setIsPanelOpen(true);
+    };
     window.addEventListener('open-maxwell', handleOpen);
     return () => window.removeEventListener('open-maxwell', handleOpen);
   }, []);
   
   // Keep component mounted on entity detail pages, dashboard, and finances, or if panel is already open.
-  if (!entityContext && !isDashboard && !isFinances && !isPanelOpen) {
+  if (!entityContext && !isDashboard && !isFinances && !isObservations && !isPanelOpen) {
     return null;
   }
   

--- a/src/components/GlobalMaxwellPanel.tsx
+++ b/src/components/GlobalMaxwellPanel.tsx
@@ -9,6 +9,7 @@ import { useMaxwellStorage, EntityContext } from '@/hooks/useMaxwellStorage';
 import { extractRecordIdsFromTrace } from '@/lib/traceParser';
 import { useMaxwellRecordHighlight } from '@/contexts/MaxwellRecordHighlightContext';
 import { useEntityContext } from '@/hooks/useEntityContext';
+import { useMaxwellStarterQuestions } from '@/hooks/useMaxwellStarterQuestions';
 import { PrismIcon } from '@/components/icons/PrismIcon';
 import { getImageUrl } from '@/lib/imageUtils';
 import { copyConversationRich } from '@/lib/urlUtils';
@@ -260,11 +261,14 @@ export function GlobalMaxwellPanel({
   }, [activeContext, messages, saveConversation]);
 
   // Select starter questions based on entity type
-  const starterQuestions = !activeContext
+  const hardcodedStarters = !activeContext
     ? STARTER_QUESTIONS_GENERAL
     : activeContext.entityType === 'action'
       ? STARTER_QUESTIONS_ACTION
       : STARTER_QUESTIONS_ASSET;
+
+  // Fetch saved questions for this user
+  const { savedQuestions, deleteQuestion } = useMaxwellStarterQuestions();
 
   const handleCopyAll = async () => {
     await copyConversationRich(messages);
@@ -430,16 +434,36 @@ export function GlobalMaxwellPanel({
         <div className="flex-1 overflow-y-auto px-4 py-2 pb-4 space-y-3 overscroll-contain touch-pan-y">
           {messages.length === 0 && !isLoading && (
             <div className="space-y-2 pt-2">
-              {starterQuestions.map((q) => (
-                <button
-                  key={q}
-                  onClick={() => sendMessage(q, maxwellMode)}
-                  disabled={isLoading}
-                  className="w-full rounded-xl border border-border bg-muted/50 px-4 py-2.5 text-left text-sm text-foreground hover:bg-muted transition-colors"
-                >
-                  {q}
-                </button>
-              ))}
+              {savedQuestions.length > 0
+                ? savedQuestions.map((q) => (
+                    <div key={q.id} className="relative group/starter">
+                      <button
+                        onClick={() => sendMessage(q.question, maxwellMode)}
+                        disabled={isLoading}
+                        className="w-full rounded-xl border border-border bg-muted/50 px-4 py-2.5 pr-8 text-left text-sm text-foreground hover:bg-muted transition-colors"
+                      >
+                        {q.question}
+                      </button>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); deleteQuestion(q.id); }}
+                        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full opacity-0 group-hover/starter:opacity-100 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-all"
+                        aria-label="Remove saved question"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  ))
+                : hardcodedStarters.map((q) => (
+                    <button
+                      key={q}
+                      onClick={() => sendMessage(q, maxwellMode)}
+                      disabled={isLoading}
+                      className="w-full rounded-xl border border-border bg-muted/50 px-4 py-2.5 text-left text-sm text-foreground hover:bg-muted transition-colors"
+                    >
+                      {q}
+                    </button>
+                  ))
+              }
             </div>
           )}
 

--- a/src/components/GlobalMaxwellPanel.tsx
+++ b/src/components/GlobalMaxwellPanel.tsx
@@ -218,7 +218,7 @@ export function GlobalMaxwellPanel({
       }
     : null;
 
-  const { messages, isLoading, progressStep, error, sendMessage, resetSession } = useMaxwell(
+  const { messages, isLoading, progressStep, error, sendMessage, resetSession, loadMessages } = useMaxwell(
     sessionAttributes || {
       entityId: '',
       entityType: 'action',
@@ -259,13 +259,6 @@ export function GlobalMaxwellPanel({
       saveConversation(activeContext, messages);
     }
   }, [activeContext, messages, saveConversation]);
-
-  // Select starter questions based on entity type
-  const hardcodedStarters = !activeContext
-    ? STARTER_QUESTIONS_GENERAL
-    : activeContext.entityType === 'action'
-      ? STARTER_QUESTIONS_ACTION
-      : STARTER_QUESTIONS_ASSET;
 
   // Fetch saved questions for this user
   const { savedQuestions, deleteQuestion } = useMaxwellStarterQuestions();
@@ -432,38 +425,31 @@ export function GlobalMaxwellPanel({
 
         {/* Message area */}
         <div className="flex-1 overflow-y-auto px-4 py-2 pb-4 space-y-3 overscroll-contain touch-pan-y">
-          {messages.length === 0 && !isLoading && (
+          {messages.length === 0 && !isLoading && savedQuestions.length > 0 && (
             <div className="space-y-2 pt-2">
-              {savedQuestions.length > 0
-                ? savedQuestions.map((q) => (
-                    <div key={q.id} className="relative group/starter">
-                      <button
-                        onClick={() => sendMessage(q.question, maxwellMode)}
-                        disabled={isLoading}
-                        className="w-full rounded-xl border border-border bg-muted/50 px-4 py-2.5 pr-8 text-left text-sm text-foreground hover:bg-muted transition-colors"
-                      >
-                        {q.question}
-                      </button>
-                      <button
-                        onClick={(e) => { e.stopPropagation(); deleteQuestion(q.id); }}
-                        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full opacity-0 group-hover/starter:opacity-100 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-all"
-                        aria-label="Remove saved question"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                  ))
-                : hardcodedStarters.map((q) => (
-                    <button
-                      key={q}
-                      onClick={() => sendMessage(q, maxwellMode)}
-                      disabled={isLoading}
-                      className="w-full rounded-xl border border-border bg-muted/50 px-4 py-2.5 text-left text-sm text-foreground hover:bg-muted transition-colors"
-                    >
-                      {q}
-                    </button>
-                  ))
-              }
+              {savedQuestions.map((q) => (
+                <div key={q.id} className="relative group/starter">
+                  <button
+                    onClick={() => {
+                      loadMessages([
+                        { role: 'user', content: q.question, timestamp: new Date(q.captured_at) },
+                        { role: 'assistant', content: q.response, timestamp: new Date(q.captured_at) },
+                      ]);
+                    }}
+                    disabled={isLoading}
+                    className="w-full rounded-xl border border-border bg-muted/50 px-4 py-2.5 pr-8 text-left text-sm text-foreground hover:bg-muted transition-colors"
+                  >
+                    {q.question}
+                  </button>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); deleteQuestion(q.id); }}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full opacity-0 group-hover/starter:opacity-100 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-all"
+                    aria-label="Remove saved question"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
             </div>
           )}
 

--- a/src/hooks/useEntityContext.ts
+++ b/src/hooks/useEntityContext.ts
@@ -7,7 +7,7 @@ import { BaseAction } from '@/types/actions';
 
 export interface EntityContext {
   entityId: string;
-  entityType: 'action' | 'tool' | 'part';
+  entityType: 'action' | 'tool' | 'part' | 'observation';
   entityName: string;
   policy: string;
   implementation: string;

--- a/src/hooks/useInvitations.tsx
+++ b/src/hooks/useInvitations.tsx
@@ -59,12 +59,21 @@ export function useInvitations(options?: UseInvitationsOptions) {
         role,
       });
 
-      toast({
-        title: "Success",
-        description: `Magic link invitation sent to ${email}`,
-      });
+      const response = data?.data || data;
 
-      return data;
+      if (response?.emailSent) {
+        toast({
+          title: "Invitation Sent",
+          description: `Invite email sent to ${email}`,
+        });
+      } else {
+        toast({
+          title: "Invitation Created",
+          description: `User added — copy the invite link below to share it with them.`,
+        });
+      }
+
+      return response;
     } catch (error) {
       console.error('Error sending invitation:', error);
       toast({

--- a/src/hooks/useMaxwell.ts
+++ b/src/hooks/useMaxwell.ts
@@ -12,7 +12,7 @@ export interface MaxwellMessage {
 
 export interface MaxwellSessionAttributes {
   entityId: string;
-  entityType: 'tool' | 'part' | 'action';
+  entityType: 'tool' | 'part' | 'action' | 'observation';
   entityName: string;
   policy: string;
   implementation: string;
@@ -34,6 +34,7 @@ export interface UseMaxwellReturn {
   sessionId: string | null;
   sendMessage: (text: string, mode?: MaxwellMode) => Promise<void>;
   resetSession: () => void;
+  loadMessages: (msgs: MaxwellMessage[]) => void;
 }
 
 /**
@@ -167,13 +168,13 @@ export function useMaxwell(sessionAttributes: MaxwellSessionAttributes): UseMaxw
       setIsLoading(false);
 
       // Fire-and-forget: save interaction to backend
-      const durationMs = lastStartTimeRef.current ? Date.now() - lastStartTimeRef.current : null;
+      const durationMs = payload?.durationMs || (lastStartTimeRef.current ? Date.now() - lastStartTimeRef.current : null);
       apiService.post('/maxwell/interactions', {
         question: lastQuestionRef.current,
         response: reply,
         model: lastModeRef.current,
-        input_tokens: null,
-        output_tokens: null,
+        input_tokens: payload?.inputTokens || null,
+        output_tokens: payload?.outputTokens || null,
         duration_ms: durationMs,
         entity_type: sessionAttributes.entityType || null,
         entity_id: sessionAttributes.entityId || null,
@@ -303,5 +304,9 @@ export function useMaxwell(sessionAttributes: MaxwellSessionAttributes): UseMaxw
     }
   }, [isLoading, messages, sessionId, sessionAttributes, status, wsSendMessage]);
 
-  return { messages, isLoading, progressStep, error, sessionId, sendMessage, resetSession };
+  const loadMessages = useCallback((msgs: MaxwellMessage[]) => {
+    setMessages(msgs);
+  }, []);
+
+  return { messages, isLoading, progressStep, error, sessionId, sendMessage, resetSession, loadMessages };
 }

--- a/src/hooks/useMaxwell.ts
+++ b/src/hooks/useMaxwell.ts
@@ -56,6 +56,10 @@ export function useMaxwell(sessionAttributes: MaxwellSessionAttributes): UseMaxw
   const accumulatedChunksRef = useRef<string>('');
   // Track whether we're currently streaming via WebSocket
   const isStreamingRef = useRef(false);
+  // Track last user question and mode for save-on-complete
+  const lastQuestionRef = useRef<string>('');
+  const lastModeRef = useRef<MaxwellMode>('deep');
+  const lastStartTimeRef = useRef<number>(0);
 
   const resetSession = useCallback(() => {
     setMessages([]);
@@ -161,6 +165,19 @@ export function useMaxwell(sessionAttributes: MaxwellSessionAttributes): UseMaxw
       isStreamingRef.current = false;
       setProgressStep(null);
       setIsLoading(false);
+
+      // Fire-and-forget: save interaction to backend
+      const durationMs = lastStartTimeRef.current ? Date.now() - lastStartTimeRef.current : null;
+      apiService.post('/maxwell/interactions', {
+        question: lastQuestionRef.current,
+        response: reply,
+        model: lastModeRef.current,
+        input_tokens: null,
+        output_tokens: null,
+        duration_ms: durationMs,
+        entity_type: sessionAttributes.entityType || null,
+        entity_id: sessionAttributes.entityId || null,
+      }).catch(() => {}); // Silent failure
     });
 
     const unsubProgress = subscribe('maxwell:progress', (payload: any) => {
@@ -216,6 +233,9 @@ export function useMaxwell(sessionAttributes: MaxwellSessionAttributes): UseMaxw
       // --- WebSocket path: send via WS and stream response ---
       accumulatedChunksRef.current = '';
       isStreamingRef.current = true;
+      lastQuestionRef.current = text;
+      lastModeRef.current = mode;
+      lastStartTimeRef.current = Date.now();
 
       wsSendMessage('maxwell:chat', {
         message: enhancedText,
@@ -262,6 +282,18 @@ export function useMaxwell(sessionAttributes: MaxwellSessionAttributes): UseMaxw
         };
 
         setMessages(prev => [...prev, assistantMsg]);
+
+        // Fire-and-forget: save interaction to backend
+        apiService.post('/maxwell/interactions', {
+          question: text,
+          response: response.reply,
+          model: mode,
+          input_tokens: null,
+          output_tokens: null,
+          duration_ms: null,
+          entity_type: sessionAttributes.entityType || null,
+          entity_id: sessionAttributes.entityId || null,
+        }).catch(() => {}); // Silent failure
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Maxwell failed to respond. Please try again.';
         setError(message);

--- a/src/hooks/useMaxwellStarterQuestions.ts
+++ b/src/hooks/useMaxwellStarterQuestions.ts
@@ -4,6 +4,7 @@ import { apiService } from '@/lib/apiService';
 interface SavedQuestion {
   id: string;
   question: string;
+  response: string;
   captured_at: string;
 }
 

--- a/src/hooks/useMaxwellStarterQuestions.ts
+++ b/src/hooks/useMaxwellStarterQuestions.ts
@@ -1,0 +1,35 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiService } from '@/lib/apiService';
+
+interface SavedQuestion {
+  id: string;
+  question: string;
+  captured_at: string;
+}
+
+export function useMaxwellStarterQuestions() {
+  const queryClient = useQueryClient();
+
+  const { data: savedQuestions = [], isLoading } = useQuery({
+    queryKey: ['maxwell-questions'],
+    queryFn: () => apiService.get<SavedQuestion[]>('/maxwell/interactions'),
+    staleTime: 60_000,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (questionId: string) =>
+      apiService.delete(`/maxwell/interactions/${questionId}`),
+    onSuccess: (_, questionId) => {
+      queryClient.setQueryData<SavedQuestion[]>(
+        ['maxwell-questions'],
+        (old) => old?.filter(q => q.id !== questionId) ?? []
+      );
+    },
+  });
+
+  return {
+    savedQuestions,
+    isLoading: isLoading,
+    deleteQuestion: deleteMutation.mutate,
+  };
+}

--- a/src/hooks/useMaxwellStorage.ts
+++ b/src/hooks/useMaxwellStorage.ts
@@ -3,7 +3,7 @@ import type { MaxwellMessage } from './useMaxwell';
 
 export interface EntityContext {
   entityId: string;
-  entityType: 'action' | 'tool' | 'part';
+  entityType: 'action' | 'tool' | 'part' | 'observation';
   entityName: string;
   policy: string;
   implementation: string;

--- a/src/pages/AcceptInvite.tsx
+++ b/src/pages/AcceptInvite.tsx
@@ -17,13 +17,13 @@ interface InviteData {
   organizationName: string;
 }
 
-type Step = 'loading' | 'choose' | 'password' | 'success' | 'error';
+type Step = 'loading' | 'choose' | 'password' | 'success' | 'error' | 'already-signed-in';
 
 export default function AcceptInvite() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { toast } = useToast();
-  const { signIn, signInWithRedirect } = useAuth();
+  const { user, signIn, signInWithRedirect, signOut } = useAuth();
 
   const [step, setStep] = useState<Step>('loading');
   const [inviteData, setInviteData] = useState<InviteData | null>(null);
@@ -70,6 +70,21 @@ export default function AcceptInvite() {
         const data = result?.data || result;
         if (data.valid) {
           setInviteData({ email: data.email, organizationId: data.organizationId, organizationName: data.organizationName });
+
+          // Check if user is already signed in as a different account
+          try {
+            const currentUser = await getCurrentUser();
+            const session = await (await import('aws-amplify/auth')).fetchAuthSession();
+            const tokenEmail = session.tokens?.idToken?.payload?.email as string | undefined;
+            const currentEmail = currentUser.signInDetails?.loginId || tokenEmail || currentUser.username;
+            if (currentEmail && currentEmail !== data.email) {
+              setStep('already-signed-in');
+              return;
+            }
+          } catch {
+            // Not signed in — continue to choose step
+          }
+
           setStep('choose');
         } else {
           setError(data.error || 'This invitation link is invalid or has expired.');
@@ -205,6 +220,42 @@ export default function AcceptInvite() {
                 Back
               </Button>
             </form>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // step === 'already-signed-in'
+  if (step === 'already-signed-in') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/5 to-secondary/5">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <AlertCircle className="h-5 w-5 text-amber-500" />
+              Already Signed In
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Alert>
+              <AlertDescription>
+                You're currently signed in as a different user. To accept this invitation for <strong>{inviteData?.email}</strong>, you need to sign out first.
+              </AlertDescription>
+            </Alert>
+            <Button
+              onClick={async () => {
+                await signOut();
+                // Reload the page so the invite flow starts fresh
+                window.location.reload();
+              }}
+              className="w-full"
+            >
+              Sign Out & Continue
+            </Button>
+            <Button variant="ghost" onClick={() => navigate('/dashboard')} className="w-full">
+              Go to Dashboard Instead
+            </Button>
           </CardContent>
         </Card>
       </div>

--- a/src/pages/ObservationsList.tsx
+++ b/src/pages/ObservationsList.tsx
@@ -37,6 +37,7 @@ import { generateObservationUrl, copyToClipboard } from '@/lib/urlUtils';
 import { getThumbnailUrl } from '@/lib/imageUtils';
 import { SharedOrgSelector } from '@/components/SharedOrgSelector';
 import { useSharedOrgs } from '@/hooks/useSharedOrgs';
+import { PrismIcon } from '@/components/icons/PrismIcon';
 export default function ObservationsList() {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -618,6 +619,34 @@ export default function ObservationsList() {
                         ) : (
                           <Handshake className="h-4 w-4" />
                         )}
+                      </Button>
+                    )}
+
+                    {!obs.is_shared_inbound && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => {
+                          const photoLines = obs.photos
+                            ?.map((p: any) => {
+                              const desc = p.photo_description || p.transcription?.replace(/^\[photo_analysis\]\s*/, '') || 'Photo';
+                              return p.photo_url ? `![${desc}](${p.photo_url})` : desc;
+                            })
+                            .filter(Boolean)
+                            .join('\n') || '';
+                          const context = {
+                            entityId: obs.id,
+                            entityType: 'observation' as any,
+                            entityName: `Observation from ${new Date(obs.captured_at).toLocaleDateString()}`,
+                            policy: obs.observation_text || '',
+                            implementation: photoLines,
+                          };
+                          window.dispatchEvent(new CustomEvent('open-maxwell', { detail: { context } }));
+                        }}
+                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                        title="Ask Maxwell about this observation"
+                      >
+                        <PrismIcon size={16} />
                       </Button>
                     )}
 

--- a/src/pages/Organization.tsx
+++ b/src/pages/Organization.tsx
@@ -8,7 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import { Trash2, Send, Users, Shield, User, Wrench, Star, Info, ToggleLeft, ToggleRight, ChevronDown, UserX, ArrowLeft, MessageSquare } from 'lucide-react';
+import { Trash2, Send, Users, Shield, User, Wrench, Star, Info, ToggleLeft, ToggleRight, ChevronDown, UserX, ArrowLeft, MessageSquare, Copy, Check, Link } from 'lucide-react';
 import { EditableOrganizationName } from '@/components/EditableOrganizationName';
 import { EditableMemberName } from '@/components/EditableMemberName';
 import { EditableOrganizationDomain } from '@/components/EditableOrganizationDomain';
@@ -60,6 +60,8 @@ const Organization = () => {
   
   const [newInviteEmail, setNewInviteEmail] = useState('');
   const [newInviteRole, setNewInviteRole] = useState('user');
+  const [lastInviteLink, setLastInviteLink] = useState<string | null>(null);
+  const [linkCopied, setLinkCopied] = useState(false);
   
   // Track which member is currently being updated
   const [updatingMemberId, setUpdatingMemberId] = useState<string | null>(null);
@@ -157,7 +159,30 @@ const Organization = () => {
     if (result) {
       setNewInviteEmail('');
       setNewInviteRole('user');
+      setLastInviteLink(result.inviteLink || null);
+      setLinkCopied(false);
       refetchMembers(); // Refresh to show new pending invitation
+    }
+  };
+
+  const handleCopyInviteLink = async () => {
+    if (!lastInviteLink) return;
+    try {
+      await navigator.clipboard.writeText(lastInviteLink);
+      setLinkCopied(true);
+      toast({ title: "Copied!", description: "Invite link copied to clipboard" });
+      setTimeout(() => setLinkCopied(false), 3000);
+    } catch {
+      // Fallback for browsers that don't support clipboard API
+      const textArea = document.createElement('textarea');
+      textArea.value = lastInviteLink;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      setLinkCopied(true);
+      toast({ title: "Copied!", description: "Invite link copied to clipboard" });
+      setTimeout(() => setLinkCopied(false), 3000);
     }
   };
 
@@ -572,6 +597,40 @@ const Organization = () => {
                   </div>
                 </div>
               </form>
+
+              {/* Invite Link Display */}
+              {lastInviteLink && (
+                <div className="mt-4 p-4 bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800 rounded-lg">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Link className="w-4 h-4 text-green-600" />
+                    <span className="text-sm font-medium text-green-900 dark:text-green-100">Invite Link Ready</span>
+                  </div>
+                  <p className="text-xs text-green-700 dark:text-green-300 mb-3">
+                    Share this link with the invited user. It expires in 24 hours.
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      readOnly
+                      value={lastInviteLink}
+                      className="text-xs font-mono bg-white dark:bg-gray-900"
+                      onClick={(e) => (e.target as HTMLInputElement).select()}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={handleCopyInviteLink}
+                      className="shrink-0"
+                    >
+                      {linkCopied ? (
+                        <><Check className="w-4 h-4 mr-1 text-green-600" /> Copied</>
+                      ) : (
+                        <><Copy className="w-4 h-4 mr-1" /> Copy</>
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              )}
             </CardContent>
           </Card>
 


### PR DESCRIPTION
## Summary

Three areas of improvement:

### Maxwell Q&A Persistence
- Starter questions now load the full previous Q&A inline (question + response) instead of re-sending
- Interactions are hard-deleted (cascading to unified_embeddings and state_links) instead of soft-deleted
- Token usage metrics (input/output tokens, duration) tracked from Bedrock agent traces
- Removed stale `deleted_at` filter since we now hard-delete

### Invite Flow UX
- `/invite-user` API now always returns `inviteLink` in the response
- Organization Settings shows a copyable invite link after inviting (for manual sharing when SES sandbox blocks delivery)
- Toast differentiates between "email sent" and "copy the link"
- Accept-invite page detects already-signed-in users and shows "Sign Out & Continue" option instead of an unresponsive Google button

### Maxwell Context for Observations
- Added `observation` entity type to context hooks
- Maxwell button on each observation in the list
- Passes observation text + photo transcriptions as context
- GlobalMaxwellFAB stays mounted on /observations routes
- Supports custom context injection via `open-maxwell` CustomEvent

## Testing
- Invited a user via Organization Settings, copied the link, and completed Google sign-in activation
- Verified already-signed-in detection and sign-out flow
- Verified Maxwell starter questions load previous responses inline