### PR TITLE
fix: show observations for shared actions

### DIFF
--- a/src/components/StatesInline.tsx
+++ b/src/components/StatesInline.tsx
@@ -35,9 +35,11 @@ import { generateObservationUrl, copyToClipboard } from '@/lib/urlUtils';
 interface StatesInlineProps {
   entity_type: 'action' | 'part' | 'tool' | 'issue' | 'policy';
   entity_id: string;
+  /** The organization_id that owns this entity. When different from the active org, observations are fetched cross-org. */
+  source_organization_id?: string;
 }
 
-export function StatesInline({ entity_type, entity_id }: StatesInlineProps) {
+export function StatesInline({ entity_type, entity_id, source_organization_id }: StatesInlineProps) {
   const { toast } = useToast();
   const { uploadFiles } = useFileUpload();
   const { user } = useAuth();
@@ -50,8 +52,16 @@ export function StatesInline({ entity_type, entity_id }: StatesInlineProps) {
     return { url: r.url };
   }, [uploadFiles]);
 
+  // When entity belongs to a different org, pass view_shared to include cross-org observations
+  const isSharedEntity = source_organization_id && source_organization_id !== orgId;
+  const viewShared = isSharedEntity ? `${orgId},${source_organization_id}` : undefined;
+
   // Fetch states for this entity
-  const { data: states, isLoading, error } = useStates(orgId, { entity_type, entity_id });
+  const { data: states, isLoading, error } = useStates(orgId, {
+    entity_type,
+    entity_id,
+    ...(viewShared ? { view_shared: viewShared } : {}),
+  });
 
   // Fetch learning objectives when entity is an action
   const { data: learningData } = useLearningObjectives(

--- a/src/components/UnifiedActionDialog.tsx
+++ b/src/components/UnifiedActionDialog.tsx
@@ -1445,6 +1445,7 @@ export function ActionForm({
               <StatesInline
                 entity_type="action"
                 entity_id={action.id}
+                source_organization_id={(action as any).organization_id}
               />
             ) : (
               <div className="text-center text-muted-foreground py-8">


### PR DESCRIPTION
## Problem

When viewing a shared action from a partner org (e.g., DA viewing a Stargazer Farm action), observations on that action weren't visible. The states query was scoped to the active org only via `buildOrganizationFilter`, excluding observations that belong to the source org.

## Fix

Uses the same `view_shared` pattern already established in `ObservationsList`:

- `StatesInline` now accepts an optional `source_organization_id` prop
- When the entity belongs to a different org, it passes `view_shared=activeOrg,sourceOrg` to the states API
- The backend's existing `view_shared` logic handles cross-org observation visibility (only shows observations linked to shared assets)
- `UnifiedActionDialog` passes `action.organization_id` to `StatesInline`

## Testing

- Open DA org → view a shared action from Stargazer Farm → observations tab should now show observations