### PR TITLE
fix: dashboard loading indicator and image URL resolution

### DIFF
--- a/src/components/shared/FileAttachmentManager.tsx
+++ b/src/components/shared/FileAttachmentManager.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Paperclip, X } from "lucide-react";
 import { useFileUpload } from "@/hooks/useFileUpload";
-import { getThumbnailUrl } from "@/lib/imageUtils";
+import { getThumbnailUrl, getImageUrl, getOriginalUrl } from "@/lib/imageUtils";
 
 interface FileAttachmentManagerProps {
   attachments: string[];
@@ -93,7 +93,7 @@ export const FileAttachmentManager = ({
                   {isPdf ? (
                     <div
                       className="h-16 w-16 flex items-center justify-center bg-muted rounded border cursor-pointer hover:bg-muted/80"
-                      onClick={() => window.open(url, '_blank')}
+                      onClick={() => window.open(getImageUrl(url) || url, '_blank')}
                     >
                       <svg className="h-8 w-8 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
@@ -104,7 +104,7 @@ export const FileAttachmentManager = ({
                       src={getThumbnailUrl(url) || ''}
                       alt={`Attachment ${index + 1}`}
                       className="h-16 w-16 object-cover rounded border cursor-pointer"
-                      onClick={() => window.open(url, '_blank')}
+                      onClick={() => window.open(getOriginalUrl(url) || getImageUrl(url) || url, '_blank')}
                       onError={(e) => {
                         // Fallback to original image if thumbnail doesn't exist yet
                         const target = e.target as HTMLImageElement;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,7 +2,7 @@ import { useAuth } from "@/hooks/useCognitoAuth";
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useNavigate } from 'react-router-dom';
-import { LogOut, CheckCircle, XCircle, Wrench, Box, Flag, ClipboardCheck, Target, BarChart3, Building2, Settings, Bot, RefreshCw, DollarSign, Search, User, Camera, Lock, ChevronDown } from 'lucide-react';
+import { LogOut, CheckCircle, XCircle, Wrench, Box, Flag, ClipboardCheck, Target, BarChart3, Building2, Settings, Bot, RefreshCw, DollarSign, Search, User, Camera, Lock, ChevronDown, Loader2 } from 'lucide-react';
 import { PrismIcon } from '@/components/icons/PrismIcon';
 import { useToast } from '@/hooks/use-toast';
 import { DebugModeToggle } from '@/components/DebugModeToggle';
@@ -16,7 +16,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { apiService } from '@/lib/apiService';
 import { offlineQueryConfig } from '@/lib/queryConfig';
 import { toolsQueryConfig, partsQueryConfig, actionsQueryConfig } from '@/lib/assetQueryConfigs';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
@@ -78,19 +78,7 @@ export default function Dashboard() {
     }
   };
 
-  // Long-press handler for sign out — prevents accidental taps on mobile
-  const signOutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const handleSignOutPointerDown = () => {
-    signOutTimerRef.current = setTimeout(() => {
-      handleSignOut();
-    }, 500);
-  };
-  const handleSignOutPointerUp = () => {
-    if (signOutTimerRef.current) {
-      clearTimeout(signOutTimerRef.current);
-      signOutTimerRef.current = null;
-    }
-  };
+
 
   const handleClearCache = async () => {
     // Clear TanStack Query cache
@@ -254,10 +242,7 @@ export default function Dashboard() {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
-                  onPointerDown={handleSignOutPointerDown}
-                  onPointerUp={handleSignOutPointerUp}
-                  onPointerLeave={handleSignOutPointerUp}
-                  onClick={(e) => e.preventDefault()}
+                  onClick={handleSignOut}
                   variant="outline"
                   size="sm"
                   className="p-2"
@@ -267,7 +252,7 @@ export default function Dashboard() {
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
-                <p>Hold to sign out</p>
+                <p>Sign out</p>
               </TooltipContent>
             </Tooltip>
           </div>
@@ -309,6 +294,23 @@ export default function Dashboard() {
                 </Card>
               );
             })}
+            {!organization && (
+              <Card className="border border-dashed border-border/50 bg-muted/30">
+                <CardHeader className="text-center">
+                  <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mx-auto mb-4">
+                    <Loader2 className="h-8 w-8 text-muted-foreground animate-spin" />
+                  </div>
+                  <CardTitle className="text-xl text-muted-foreground">Loading...</CardTitle>
+                  <CardDescription>Loading additional modules</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button className="w-full" variant="outline" disabled>
+                    <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                    Please wait
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
- Add loading spinner card while organization data loads (non-core modules)
- Remove hold-to-sign-out, use standard click button
- Fix FileAttachmentManager opening relative S3 keys against page origin instead of resolving to full S3 URLs via getImageUrl/getOriginalUrl